### PR TITLE
feat(pipeline): GraphQL ingest, atomic refresh, OSS daily contributions

### DIFF
--- a/.github/workflows/daily_stats.yml
+++ b/.github/workflows/daily_stats.yml
@@ -9,59 +9,17 @@ on:
 jobs:
   refresh-stats:
     runs-on: ubuntu-latest
-    
+
     steps:
-      - name: Get ready users
-        id: get-users
+      - name: Run GraphQL refresh for all users
         run: |
-          echo "Fetching ready users..."
-          RESPONSE=$(curl -s -H "accept: */*" \
-            -H "X-API-Key: ${{ secrets.API_KEY }}" \
-            "https://friends-activity-backend-production.up.railway.app/pipeline/listUsers")
-          
-          # Extract only users from the 'ready' status group
-          USERS=$(echo $RESPONSE | jq -c '.ready.users')
-          USER_COUNT=$(echo $RESPONSE | jq -r '.ready.users | length')
-          
-          echo "users=$USERS" >> $GITHUB_OUTPUT
-          echo "Found $USER_COUNT ready users"
-          echo "Users JSON: $USERS"
-
-      - name: Check if there are users to process
-        id: check-users
-        run: |
-          USER_COUNT=$(echo '${{ steps.get-users.outputs.users }}' | jq '. | length')
-          if [ "$USER_COUNT" -eq 0 ]; then
-            echo "No ready users found. Skipping stats refresh."
-            echo "skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "Processing $USER_COUNT users"
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Run pipeline stats
-        if: steps.check-users.outputs.skip == 'false'
-        run: |
-          echo "Triggering pipeline stats for ready users..."
-          PAYLOAD=$(jq -n --argjson users '${{ steps.get-users.outputs.users }}' '{users: $users}')
-          echo "Payload: $PAYLOAD"
-          
-          # Send request without waiting for response (fire and forget)
           HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-            -H "accept: */*" \
             -H "X-API-Key: ${{ secrets.API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD" \
-            "https://friends-activity-backend-production.up.railway.app/pipeline/stats")
-          
-          echo "Request sent with HTTP status: $HTTP_CODE"
-          echo "✅ Pipeline stats request triggered successfully!"
+            "https://friends-activity-backend-production.up.railway.app/pipeline/v2/refreshAll")
 
-      - name: Summary
-        if: always()
-        run: |
-          if [ "${{ steps.check-users.outputs.skip }}" == "true" ]; then
-            echo "✅ No users needed processing"
-          else
-            echo "✅ Stats refresh request sent for ready users"
+          echo "Completed with HTTP status: $HTTP_CODE"
+          if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
+            echo "❌ Refresh failed with status $HTTP_CODE"
+            exit 1
           fi
+          echo "✅ Refresh completed successfully"

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,3 @@
-// src/app.module.ts
 import 'dotenv/config';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -6,18 +5,22 @@ import { APP_GUARD } from '@nestjs/core';
 
 import dataSource from './database/data-source.js';
 import { AppController } from './app.controller.js';
-import { GithubModule } from './raw/raw.module.js';
-import { NormalizedModule } from './normalized/normalized.module.js';
 import { AnalyticsModule } from './analytics/analytics.module.js';
 import { PipelineModule } from './pipeline/pipeline.module.js';
+import { IngestModule } from './ingest/ingest.module.js';
+import { PipelineV2Module } from './pipeline-v2/pipeline-v2.module.js';
 import { ApiKeyGuard } from './auth/api-key.guard.js';
 
 function pgConfig() {
   if (process.env.DATABASE_URL) {
+    const ssl =
+      process.env.DATABASE_SSL === 'false'
+        ? false
+        : { rejectUnauthorized: false };
     return {
       type: 'postgres' as const,
       url: process.env.DATABASE_URL,
-      ssl: { rejectUnauthorized: false },
+      ssl,
       autoLoadEntities: true,
       synchronize: false,
     };
@@ -32,10 +35,10 @@ function pgConfig() {
 @Module({
   imports: [
     TypeOrmModule.forRoot(pgConfig()),
-    GithubModule,
-    NormalizedModule,
     AnalyticsModule,
+    IngestModule,
     PipelineModule,
+    PipelineV2Module,
   ],
   controllers: [AppController],
   providers: [

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -1,4 +1,3 @@
-// src/database/data-source.ts
 import 'reflect-metadata';
 import 'dotenv/config';
 
@@ -6,31 +5,50 @@ import { DataSource } from 'typeorm';
 import { fileURLToPath } from 'url';
 import path from 'path';
 
+import { InitSchemas1755604729706 } from './migrations/1755604729706-InitSchemas.js';
+import { AddUserProfile1755614062187 } from './migrations/1755614062187-AddUserProfile.js';
+import { AddBronzeUsersAndRepos1755615000000 } from './migrations/1755615000000-AddBronzeUsersAndRepos.js';
+import { AddGoldRepository1755616000000 } from './migrations/1755616000000-AddGoldRepository.js';
+import { AddProcessingStatusToUsers1755617000000 } from './migrations/1755617000000-AddProcessingStatusToUsers.js';
+import { AddProcessingQueue1755618000000 } from './migrations/1755618000000-AddProcessingQueue.js';
+import { AddMissingFields1755620000000 } from './migrations/1755620000000-AddMissingFields.js';
+import { AddOwnerUserIdToRepository1755625000000 } from './migrations/1755625000000-AddOwnerUserIdToRepository.js';
+import { AddLastSyncedAtToUsers1755630000000 } from './migrations/1755630000000-AddLastSyncedAtToUsers.js';
+import { CreateGraphqlPipelineTables1755900000000 } from './migrations/1755900000000-CreateGraphqlPipelineTables.js';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const isProd = process.env.NODE_ENV === 'production';
 const DATABASE_URL = process.env.DATABASE_URL;
 
-const migrationsGlob = isProd
-  ? path.join(__dirname, 'migrations', '*.js')
-  : path.join(__dirname, 'migrations', '*.ts');
-
 const entitiesArr: string[] = [
-  // Raw entities
   path.join(__dirname, '..', 'raw', '**', '*.entity.{ts,js}'),
-  // Curated entities
   path.join(__dirname, '..', 'analytics', '**', '*.entity.{ts,js}'),
+  path.join(__dirname, 'entities', '**', '*.entity.{ts,js}'),
 ];
+
+const ssl =
+  process.env.DATABASE_SSL === 'false' ? false : { rejectUnauthorized: false };
 
 const dataSource = new DataSource({
   type: 'postgres',
   url: DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
+  ssl,
 
   entities: entitiesArr,
 
-  migrations: [migrationsGlob],
+  migrations: [
+    InitSchemas1755604729706,
+    AddUserProfile1755614062187,
+    AddBronzeUsersAndRepos1755615000000,
+    AddGoldRepository1755616000000,
+    AddProcessingStatusToUsers1755617000000,
+    AddProcessingQueue1755618000000,
+    AddMissingFields1755620000000,
+    AddOwnerUserIdToRepository1755625000000,
+    AddLastSyncedAtToUsers1755630000000,
+    CreateGraphqlPipelineTables1755900000000,
+  ],
   migrationsTableName: 'typeorm_migrations',
   schema: 'public',
   logging: false,

--- a/src/database/entities/app/repository.entity.ts
+++ b/src/database/entities/app/repository.entity.ts
@@ -1,0 +1,41 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'repository' })
+export class AppRepositoryEntity {
+  @PrimaryColumn('varchar', { length: 64, name: 'repo_id' })
+  repoId!: string;
+
+  @Column('varchar', { length: 512, name: 'repo_name' })
+  repoName!: string;
+
+  @Column('text', { nullable: true })
+  description!: string | null;
+
+  @Column('text', { nullable: true, name: 'html_url' })
+  htmlUrl!: string | null;
+
+  @Column('integer', { default: 0, name: 'fork_count' })
+  forkCount!: number;
+
+  @Column('integer', { default: 0, name: 'stargazer_count' })
+  stargazerCount!: number;
+
+  @Column('varchar', { length: 255, nullable: true, name: 'primary_language' })
+  primaryLanguage!: string | null;
+
+  @Column('varchar', {
+    length: 32,
+    nullable: true,
+    name: 'primary_language_color',
+  })
+  primaryLanguageColor!: string | null;
+
+  @Column('varchar', { length: 255, nullable: true, name: 'license_name' })
+  licenseName!: string | null;
+
+  @Column('varchar', { length: 64, nullable: true, name: 'license_spdx' })
+  licenseSpdx!: string | null;
+
+  @Column('text', { array: true, nullable: true })
+  topics!: string[] | null;
+}

--- a/src/database/entities/app/user-activity.entity.ts
+++ b/src/database/entities/app/user-activity.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'user_activity' })
+export class AppUserActivityEntity {
+  @PrimaryColumn('varchar', { length: 64, name: 'user_id' })
+  userId!: string;
+
+  @PrimaryColumn('date')
+  day!: Date;
+
+  @PrimaryColumn('varchar', { length: 64, name: 'repo_id' })
+  repoId!: string;
+
+  @PrimaryColumn('varchar', { length: 32, name: 'activity_type' })
+  activityType!: string;
+
+  @Column('integer', { default: 0, name: 'activity_count' })
+  activityCount!: number;
+}

--- a/src/database/entities/app/user-daily-contribution.entity.ts
+++ b/src/database/entities/app/user-daily-contribution.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'user_daily_contribution' })
+export class AppUserDailyContributionEntity {
+  @PrimaryColumn('varchar', { length: 64, name: 'user_id' })
+  userId!: string;
+
+  @PrimaryColumn('date')
+  day!: Date;
+
+  @Column('integer', { default: 0 })
+  count!: number;
+}

--- a/src/database/entities/app/user-profile.entity.ts
+++ b/src/database/entities/app/user-profile.entity.ts
@@ -1,0 +1,52 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'user_profile' })
+export class AppUserProfileEntity {
+  @PrimaryColumn('varchar', { length: 64, name: 'user_id' })
+  userId!: string;
+
+  @Column('varchar', { length: 255 })
+  login!: string;
+
+  @Column('varchar', { length: 255, nullable: true })
+  name!: string | null;
+
+  @Column('text', { nullable: true, name: 'avatar_url' })
+  avatarUrl!: string | null;
+
+  @Column('text', { nullable: true, name: 'html_url' })
+  htmlUrl!: string | null;
+
+  @Column('varchar', { length: 255, nullable: true })
+  company!: string | null;
+
+  @Column('varchar', { length: 255, nullable: true })
+  location!: string | null;
+
+  @Column('text', { nullable: true })
+  bio!: string | null;
+
+  @Column('text', { nullable: true })
+  blog!: string | null;
+
+  @Column('varchar', { length: 255, nullable: true, name: 'twitter_username' })
+  twitterUsername!: string | null;
+
+  @Column('integer', { default: 0, name: 'public_repos' })
+  publicRepos!: number;
+
+  @Column('integer', { default: 0 })
+  followers!: number;
+
+  @Column('integer', { default: 0 })
+  following!: number;
+
+  @Column('varchar', { length: 64, nullable: true })
+  type!: string | null;
+
+  @Column('timestamptz', { nullable: true, name: 'gh_created_at' })
+  ghCreatedAt!: Date | null;
+
+  @Column('timestamptz', { nullable: true, name: 'fetched_at' })
+  fetchedAt!: Date | null;
+}

--- a/src/database/entities/app/user-sync.entity.ts
+++ b/src/database/entities/app/user-sync.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'user_sync' })
+export class AppUserSyncEntity {
+  @PrimaryColumn('varchar', { length: 255 })
+  login!: string;
+
+  @Column('varchar', { length: 64, nullable: true, name: 'user_id' })
+  userId!: string | null;
+
+  @Column('varchar', { length: 32 })
+  status!: string;
+
+  @Column('timestamptz', { nullable: true, name: 'last_synced_at' })
+  lastSyncedAt!: Date | null;
+
+  @Column('text', { nullable: true, name: 'last_error' })
+  lastError!: string | null;
+
+  @Column('timestamptz', { nullable: true, name: 'updated_at' })
+  updatedAt!: Date | null;
+}

--- a/src/database/migrations/1755900000000-CreateGraphqlPipelineTables.ts
+++ b/src/database/migrations/1755900000000-CreateGraphqlPipelineTables.ts
@@ -1,0 +1,93 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateGraphqlPipelineTables1755900000000
+  implements MigrationInterface
+{
+  name = 'CreateGraphqlPipelineTables1755900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS user_profile (
+        user_id          VARCHAR(64) PRIMARY KEY,
+        login            VARCHAR(255) NOT NULL,
+        name             VARCHAR(255),
+        avatar_url       TEXT,
+        html_url         TEXT,
+        company          VARCHAR(255),
+        location         VARCHAR(255),
+        bio              TEXT,
+        blog             TEXT,
+        twitter_username VARCHAR(255),
+        public_repos     INTEGER DEFAULT 0,
+        followers        INTEGER DEFAULT 0,
+        following        INTEGER DEFAULT 0,
+        type             VARCHAR(64),
+        gh_created_at    TIMESTAMPTZ,
+        fetched_at       TIMESTAMPTZ DEFAULT NOW()
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS idx_user_profile_login ON user_profile (login)`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS repository (
+        repo_id                VARCHAR(64) PRIMARY KEY,
+        repo_name              VARCHAR(512) NOT NULL,
+        description            TEXT,
+        html_url               TEXT,
+        fork_count             INTEGER DEFAULT 0,
+        stargazer_count        INTEGER DEFAULT 0,
+        primary_language       VARCHAR(255),
+        primary_language_color VARCHAR(32),
+        license_name           VARCHAR(255),
+        license_spdx           VARCHAR(64),
+        topics                 TEXT[]
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS idx_repository_name ON repository (repo_name)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS idx_repository_fork_count ON repository (fork_count) WHERE fork_count >= 3`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS user_activity (
+        user_id        VARCHAR(64) NOT NULL,
+        day            DATE NOT NULL,
+        repo_id        VARCHAR(64) NOT NULL,
+        activity_type  VARCHAR(32) NOT NULL,
+        activity_count INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (user_id, day, repo_id, activity_type)
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS idx_user_activity_repo ON user_activity (repo_id)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS idx_user_activity_day ON user_activity (day)`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS user_sync (
+        login          VARCHAR(255) PRIMARY KEY,
+        user_id        VARCHAR(64),
+        status         VARCHAR(32) NOT NULL,
+        last_synced_at TIMESTAMPTZ,
+        last_error     TEXT,
+        updated_at     TIMESTAMPTZ DEFAULT NOW()
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS idx_user_sync_status ON user_sync (status)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS user_sync`);
+    await queryRunner.query(`DROP TABLE IF EXISTS user_activity`);
+    await queryRunner.query(`DROP TABLE IF EXISTS repository`);
+    await queryRunner.query(`DROP TABLE IF EXISTS user_profile`);
+  }
+}

--- a/src/database/migrations/1755900000000-CreateGraphqlPipelineTables.ts
+++ b/src/database/migrations/1755900000000-CreateGraphqlPipelineTables.ts
@@ -82,9 +82,22 @@ export class CreateGraphqlPipelineTables1755900000000
     await queryRunner.query(
       `CREATE INDEX IF NOT EXISTS idx_user_sync_status ON user_sync (status)`,
     );
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS user_daily_contribution (
+        user_id VARCHAR(64) NOT NULL,
+        day     DATE NOT NULL,
+        count   INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (user_id, day)
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS idx_user_daily_contribution_day ON user_daily_contribution (day)`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS user_daily_contribution`);
     await queryRunner.query(`DROP TABLE IF EXISTS user_sync`);
     await queryRunner.query(`DROP TABLE IF EXISTS user_activity`);
     await queryRunner.query(`DROP TABLE IF EXISTS repository`);

--- a/src/ingest/__tests__/aggregate.spec.ts
+++ b/src/ingest/__tests__/aggregate.spec.ts
@@ -1,0 +1,286 @@
+import { aggregate } from '../aggregate.js';
+import type {
+  IssueCommentNode,
+  PullRequestReviewNode,
+  RepoMetadata,
+  UserNode,
+} from '../graphql-types.js';
+import type { OverflowCounts } from '../overflow.js';
+
+const repoRef = (id: string, nameWithOwner: string, databaseId = 1) => ({
+  id,
+  databaseId,
+  nameWithOwner,
+});
+
+const userBase = (
+  overrides: Partial<UserNode['contributionsCollection']> = {},
+): UserNode => ({
+  id: 'U_1',
+  databaseId: 1,
+  login: 'tester',
+  name: null,
+  avatarUrl: '',
+  url: '',
+  bio: null,
+  location: null,
+  company: null,
+  websiteUrl: null,
+  twitterUsername: null,
+  createdAt: '2020-01-01T00:00:00Z',
+  followers: { totalCount: 0 },
+  following: { totalCount: 0 },
+  repositories: { totalCount: 0 },
+  contributionsCollection: {
+    totalCommitContributions: 0,
+    totalPullRequestContributions: 0,
+    totalIssueContributions: 0,
+    totalPullRequestReviewContributions: 0,
+    totalRepositoriesWithContributedCommits: 0,
+    totalRepositoriesWithContributedPullRequests: 0,
+    totalRepositoriesWithContributedIssues: 0,
+    totalRepositoriesWithContributedPullRequestReviews: 0,
+    commitContributionsByRepository: [],
+    pullRequestContributionsByRepository: [],
+    issueContributionsByRepository: [],
+    pullRequestReviewContributionsByRepository: [],
+    ...overrides,
+  },
+  issueComments: {
+    totalCount: 0,
+    pageInfo: { hasPreviousPage: false, startCursor: null },
+    nodes: [],
+  },
+});
+
+const meta = (
+  nameWithOwner: string,
+  fields: Partial<RepoMetadata> = {},
+): RepoMetadata => ({
+  id: 'R_' + nameWithOwner,
+  databaseId: 1,
+  nameWithOwner,
+  description: null,
+  url: '',
+  forkCount: 0,
+  isPrivate: false,
+  stargazerCount: 0,
+  primaryLanguage: null,
+  licenseInfo: null,
+  repositoryTopics: {
+    pageInfo: { hasNextPage: false, endCursor: null },
+    nodes: [],
+  },
+  ...fields,
+});
+
+describe('aggregate', () => {
+  it('places contribution counts into matching repo buckets', () => {
+    const user = userBase({
+      commitContributionsByRepository: [
+        {
+          repository: repoRef('R_a', 'org/a'),
+          contributions: { totalCount: 5 },
+        },
+      ],
+      pullRequestContributionsByRepository: [
+        {
+          repository: repoRef('R_a', 'org/a'),
+          contributions: { totalCount: 2 },
+        },
+      ],
+      issueContributionsByRepository: [
+        {
+          repository: repoRef('R_b', 'org/b'),
+          contributions: { totalCount: 3 },
+        },
+      ],
+      pullRequestReviewContributionsByRepository: [
+        {
+          repository: repoRef('R_a', 'org/a'),
+          contributions: { totalCount: 4 },
+        },
+      ],
+    });
+
+    const result = aggregate(user, [], [], new Map(), new Map());
+
+    expect(result.get('org/a')).toMatchObject({
+      commits: 5,
+      pullRequests: 2,
+      prReviews: 4,
+      issues: 0,
+    });
+    expect(result.get('org/b')).toMatchObject({ issues: 3, commits: 0 });
+  });
+
+  it('routes user.issueComments with pullRequest set to prComments', () => {
+    const user = userBase();
+    const comments: IssueCommentNode[] = [
+      {
+        createdAt: '2026-01-01T00:00:00Z',
+        repository: { id: 'R_a', databaseId: 1, nameWithOwner: 'org/a' },
+        issue: null,
+        pullRequest: { id: 'P1' },
+      },
+      {
+        createdAt: '2026-01-02T00:00:00Z',
+        repository: { id: 'R_a', databaseId: 1, nameWithOwner: 'org/a' },
+        issue: null,
+        pullRequest: { id: 'P2' },
+      },
+    ];
+    const result = aggregate(user, comments, [], new Map(), new Map());
+    expect(result.get('org/a')).toMatchObject({
+      prComments: 2,
+      issueComments: 0,
+    });
+  });
+
+  it('routes user.issueComments with issue set to issueComments', () => {
+    const user = userBase();
+    const comments: IssueCommentNode[] = [
+      {
+        createdAt: '2026-01-01T00:00:00Z',
+        repository: { id: 'R_a', databaseId: 1, nameWithOwner: 'org/a' },
+        issue: { id: 'I1' },
+        pullRequest: null,
+      },
+    ];
+    const result = aggregate(user, comments, [], new Map(), new Map());
+    expect(result.get('org/a')).toMatchObject({
+      issueComments: 1,
+      prComments: 0,
+    });
+  });
+
+  it('sums review.comments.totalCount per repo into prComments', () => {
+    const user = userBase();
+    const reviews: PullRequestReviewNode[] = [
+      {
+        createdAt: '2026-01-01T00:00:00Z',
+        repository: { id: 'R_a', databaseId: 1, nameWithOwner: 'org/a' },
+        comments: { totalCount: 3 },
+      },
+      {
+        createdAt: '2026-01-02T00:00:00Z',
+        repository: { id: 'R_a', databaseId: 1, nameWithOwner: 'org/a' },
+        comments: { totalCount: 7 },
+      },
+    ];
+    const result = aggregate(user, [], reviews, new Map(), new Map());
+    expect(result.get('org/a')?.prComments).toBe(10);
+  });
+
+  it('combines PR-conversation comments and inline review comments', () => {
+    const user = userBase();
+    const comments: IssueCommentNode[] = [
+      {
+        createdAt: '2026-01-01T00:00:00Z',
+        repository: { id: 'R_a', databaseId: 1, nameWithOwner: 'org/a' },
+        issue: null,
+        pullRequest: { id: 'P1' },
+      },
+    ];
+    const reviews: PullRequestReviewNode[] = [
+      {
+        createdAt: '2026-01-02T00:00:00Z',
+        repository: { id: 'R_a', databaseId: 1, nameWithOwner: 'org/a' },
+        comments: { totalCount: 5 },
+      },
+    ];
+    const result = aggregate(user, comments, reviews, new Map(), new Map());
+    expect(result.get('org/a')?.prComments).toBe(6);
+  });
+
+  it('attaches metadata (description, language, topics) from the metadata map', () => {
+    const user = userBase({
+      commitContributionsByRepository: [
+        {
+          repository: repoRef('R_a', 'org/a'),
+          contributions: { totalCount: 1 },
+        },
+      ],
+    });
+    const md = new Map([
+      [
+        'org/a',
+        meta('org/a', {
+          description: 'cool repo',
+          url: 'https://example.test/a',
+          stargazerCount: 42,
+          primaryLanguage: { name: 'TypeScript', color: '#3178C6' },
+          licenseInfo: { name: 'MIT', spdxId: 'MIT' },
+          repositoryTopics: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              { topic: { name: 'typescript' } },
+              { topic: { name: 'graphql' } },
+            ],
+          },
+        }),
+      ],
+    ]);
+    const result = aggregate(user, [], [], md, new Map());
+    const bucket = result.get('org/a');
+    expect(bucket).toMatchObject({
+      description: 'cool repo',
+      url: 'https://example.test/a',
+      stargazerCount: 42,
+      primaryLanguage: 'TypeScript',
+      primaryLanguageColor: '#3178C6',
+      licenseName: 'MIT',
+      licenseSpdx: 'MIT',
+      topics: ['typescript', 'graphql'],
+    });
+  });
+
+  it('overflow counts overwrite bucket counts for same repo', () => {
+    const user = userBase({
+      commitContributionsByRepository: [
+        {
+          repository: repoRef('R_a', 'org/a'),
+          contributions: { totalCount: 50 },
+        },
+      ],
+    });
+    const overflow = new Map<string, OverflowCounts>([
+      ['org/a', { commits: 200, prs: 0, issues: 0, reviews: 0 }],
+    ]);
+    const result = aggregate(user, [], [], new Map(), overflow);
+    expect(result.get('org/a')?.commits).toBe(200);
+  });
+
+  it('overflow zero counts do not overwrite existing non-zero bucket counts', () => {
+    const user = userBase({
+      commitContributionsByRepository: [
+        {
+          repository: repoRef('R_a', 'org/a'),
+          contributions: { totalCount: 7 },
+        },
+      ],
+    });
+    const overflow = new Map<string, OverflowCounts>([
+      ['org/a', { commits: 0, prs: 5, issues: 0, reviews: 0 }],
+    ]);
+    const result = aggregate(user, [], [], new Map(), overflow);
+    expect(result.get('org/a')?.commits).toBe(7);
+    expect(result.get('org/a')?.pullRequests).toBe(5);
+  });
+
+  it('creates a bucket for an overflow-only repo (not seen elsewhere)', () => {
+    const user = userBase();
+    const md = new Map([['org/x', meta('org/x', { stargazerCount: 99 })]]);
+    const overflow = new Map<string, OverflowCounts>([
+      ['org/x', { commits: 1, prs: 2, issues: 3, reviews: 4 }],
+    ]);
+    const result = aggregate(user, [], [], md, overflow);
+    expect(result.get('org/x')).toMatchObject({
+      commits: 1,
+      pullRequests: 2,
+      issues: 3,
+      prReviews: 4,
+      stargazerCount: 99,
+    });
+  });
+});

--- a/src/ingest/__tests__/overflow.spec.ts
+++ b/src/ingest/__tests__/overflow.spec.ts
@@ -1,0 +1,211 @@
+import { fetchOverflowCounts } from '../overflow.js';
+import type { GraphqlClient } from '../graphql-client.js';
+
+interface MockCall {
+  query: string;
+  variables: Record<string, unknown>;
+}
+
+const mockClient = (
+  responses: unknown[],
+): { client: GraphqlClient; calls: MockCall[] } => {
+  const calls: MockCall[] = [];
+  let i = 0;
+  const client = {
+    call: <T>(
+      query: string,
+      variables: Record<string, unknown>,
+    ): Promise<T> => {
+      calls.push({ query, variables });
+      const r = responses[i++] ?? {};
+      return Promise.resolve(r as T);
+    },
+  } as unknown as GraphqlClient;
+  return { client, calls };
+};
+
+const repo = (nameWithOwner: string) => ({
+  id: 'R_' + nameWithOwner,
+  databaseId: 1,
+  nameWithOwner,
+});
+
+describe('fetchOverflowCounts query construction', () => {
+  it('returns empty map when no overflow', async () => {
+    const { client, calls } = mockClient([]);
+    const out = await fetchOverflowCounts(
+      client,
+      'tester',
+      'U_1',
+      '2025-10-29T00:00:00Z',
+      {
+        COMMIT: [],
+        PULL_REQUEST: [],
+        ISSUE: [],
+        PULL_REQUEST_REVIEW: [],
+      },
+    );
+    expect(out.size).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('declares $since and $authorId only when commit fragments are present', async () => {
+    const { client, calls } = mockClient([
+      {
+        commit0: {
+          defaultBranchRef: { target: { history: { totalCount: 42 } } },
+        },
+      },
+    ]);
+    await fetchOverflowCounts(client, 'tester', 'U_1', '2025-10-29T00:00:00Z', {
+      COMMIT: [repo('org/a')],
+      PULL_REQUEST: [],
+      ISSUE: [],
+      PULL_REQUEST_REVIEW: [],
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].query).toContain('$since: GitTimestamp!');
+    expect(calls[0].query).toContain('$authorId: ID!');
+    expect(calls[0].variables).toMatchObject({
+      since: '2025-10-29T00:00:00Z',
+      authorId: 'U_1',
+    });
+  });
+
+  it('omits $since and $authorId when only search fragments are present', async () => {
+    const { client, calls } = mockClient([
+      {
+        pr0: { issueCount: 5 },
+        issue1: { issueCount: 3 },
+        review2: { issueCount: 1 },
+      },
+    ]);
+    await fetchOverflowCounts(client, 'tester', 'U_1', '2025-10-29T00:00:00Z', {
+      COMMIT: [],
+      PULL_REQUEST: [repo('org/a')],
+      ISSUE: [repo('org/b')],
+      PULL_REQUEST_REVIEW: [repo('org/c')],
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].query).not.toContain('$since:');
+    expect(calls[0].query).not.toContain('$authorId:');
+    expect(calls[0].variables).not.toHaveProperty('since');
+    expect(calls[0].variables).not.toHaveProperty('authorId');
+  });
+
+  it('declares all variables when commit and search fragments are mixed', async () => {
+    const { client, calls } = mockClient([
+      {
+        commit0: {
+          defaultBranchRef: { target: { history: { totalCount: 10 } } },
+        },
+        pr1: { issueCount: 5 },
+      },
+    ]);
+    await fetchOverflowCounts(client, 'tester', 'U_1', '2025-10-29T00:00:00Z', {
+      COMMIT: [repo('org/a')],
+      PULL_REQUEST: [repo('org/b')],
+      ISSUE: [],
+      PULL_REQUEST_REVIEW: [],
+    });
+    expect(calls[0].query).toContain('$since: GitTimestamp!');
+    expect(calls[0].query).toContain('$authorId: ID!');
+  });
+
+  it('builds search qualifiers with the correct repo + login + since for each kind', async () => {
+    const { client, calls } = mockClient([
+      {
+        pr0: { issueCount: 0 },
+        issue1: { issueCount: 0 },
+        review2: { issueCount: 0 },
+      },
+    ]);
+    await fetchOverflowCounts(client, 'tester', 'U_1', '2025-10-29T00:00:00Z', {
+      COMMIT: [],
+      PULL_REQUEST: [repo('org/p')],
+      ISSUE: [repo('org/i')],
+      PULL_REQUEST_REVIEW: [repo('org/r')],
+    });
+    const v = calls[0].variables;
+    expect(v.pr0_q).toBe(
+      'repo:org/p author:tester is:pr created:>=2025-10-29T00:00:00Z',
+    );
+    expect(v.issue1_q).toBe(
+      'repo:org/i author:tester is:issue created:>=2025-10-29T00:00:00Z',
+    );
+    expect(v.review2_q).toBe(
+      'repo:org/r reviewed-by:tester is:pr updated:>=2025-10-29T00:00:00Z',
+    );
+  });
+
+  it('chunks large overflow into batches of 25', async () => {
+    const repos = Array.from({ length: 60 }, (_, i) => repo(`org/r${i}`));
+    const responses = [
+      Object.fromEntries(
+        repos.slice(0, 25).map((_, i) => [`pr${i}`, { issueCount: 0 }]),
+      ),
+      Object.fromEntries(
+        repos.slice(25, 50).map((_, i) => [`pr${i}`, { issueCount: 0 }]),
+      ),
+      Object.fromEntries(
+        repos.slice(50, 60).map((_, i) => [`pr${i}`, { issueCount: 0 }]),
+      ),
+    ];
+    const { client, calls } = mockClient(responses);
+    await fetchOverflowCounts(client, 'tester', 'U_1', '2025-10-29T00:00:00Z', {
+      COMMIT: [],
+      PULL_REQUEST: repos,
+      ISSUE: [],
+      PULL_REQUEST_REVIEW: [],
+    });
+    expect(calls).toHaveLength(3);
+  });
+
+  it('extracts commit history totalCount from response and writes to bucket', async () => {
+    const { client } = mockClient([
+      {
+        commit0: {
+          defaultBranchRef: { target: { history: { totalCount: 99 } } },
+        },
+      },
+    ]);
+    const out = await fetchOverflowCounts(
+      client,
+      'tester',
+      'U_1',
+      '2025-10-29T00:00:00Z',
+      {
+        COMMIT: [repo('org/a')],
+        PULL_REQUEST: [],
+        ISSUE: [],
+        PULL_REQUEST_REVIEW: [],
+      },
+    );
+    expect(out.get('org/a')).toMatchObject({ commits: 99 });
+  });
+
+  it('extracts search issueCount and writes to correct bucket field', async () => {
+    const { client } = mockClient([
+      {
+        pr0: { issueCount: 7 },
+        issue1: { issueCount: 11 },
+        review2: { issueCount: 13 },
+      },
+    ]);
+    const out = await fetchOverflowCounts(
+      client,
+      'tester',
+      'U_1',
+      '2025-10-29T00:00:00Z',
+      {
+        COMMIT: [],
+        PULL_REQUEST: [repo('org/p')],
+        ISSUE: [repo('org/i')],
+        PULL_REQUEST_REVIEW: [repo('org/r')],
+      },
+    );
+    expect(out.get('org/p')?.prs).toBe(7);
+    expect(out.get('org/i')?.issues).toBe(11);
+    expect(out.get('org/r')?.reviews).toBe(13);
+  });
+});

--- a/src/ingest/__tests__/overflow.spec.ts
+++ b/src/ingest/__tests__/overflow.spec.ts
@@ -28,6 +28,7 @@ const repo = (nameWithOwner: string) => ({
   id: 'R_' + nameWithOwner,
   databaseId: 1,
   nameWithOwner,
+  forkCount: 10,
 });
 
 describe('fetchOverflowCounts query construction', () => {
@@ -66,10 +67,6 @@ describe('fetchOverflowCounts query construction', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].query).toContain('$since: GitTimestamp!');
     expect(calls[0].query).toContain('$authorId: ID!');
-    expect(calls[0].variables).toMatchObject({
-      since: '2025-10-29T00:00:00Z',
-      authorId: 'U_1',
-    });
   });
 
   it('omits $since and $authorId when only search fragments are present', async () => {
@@ -91,25 +88,6 @@ describe('fetchOverflowCounts query construction', () => {
     expect(calls[0].query).not.toContain('$authorId:');
     expect(calls[0].variables).not.toHaveProperty('since');
     expect(calls[0].variables).not.toHaveProperty('authorId');
-  });
-
-  it('declares all variables when commit and search fragments are mixed', async () => {
-    const { client, calls } = mockClient([
-      {
-        commit0: {
-          defaultBranchRef: { target: { history: { totalCount: 10 } } },
-        },
-        pr1: { issueCount: 5 },
-      },
-    ]);
-    await fetchOverflowCounts(client, 'tester', 'U_1', '2025-10-29T00:00:00Z', {
-      COMMIT: [repo('org/a')],
-      PULL_REQUEST: [repo('org/b')],
-      ISSUE: [],
-      PULL_REQUEST_REVIEW: [],
-    });
-    expect(calls[0].query).toContain('$since: GitTimestamp!');
-    expect(calls[0].query).toContain('$authorId: ID!');
   });
 
   it('builds search qualifiers with the correct repo + login + since for each kind', async () => {

--- a/src/ingest/__tests__/pagination.spec.ts
+++ b/src/ingest/__tests__/pagination.spec.ts
@@ -1,0 +1,251 @@
+import {
+  paginateIssueComments,
+  fetchPRReviewsInWindow,
+} from '../pagination.js';
+import type { GraphqlClient } from '../graphql-client.js';
+import type { UserNode } from '../graphql-types.js';
+
+interface MockCall {
+  query: string;
+  variables: Record<string, unknown>;
+}
+
+const mockClient = (
+  responses: unknown[],
+): { client: GraphqlClient; calls: MockCall[] } => {
+  const calls: MockCall[] = [];
+  let i = 0;
+  const client = {
+    call: <T>(
+      query: string,
+      variables: Record<string, unknown>,
+    ): Promise<T> => {
+      calls.push({ query, variables });
+      const r = responses[i++];
+      return Promise.resolve(r as T);
+    },
+  } as unknown as GraphqlClient;
+  return { client, calls };
+};
+
+const userWithComments = (
+  nodes: Array<{ createdAt: string; cursor?: string }>,
+  startCursor: string | null,
+  hasPrevious: boolean,
+): UserNode =>
+  ({
+    id: 'U_1',
+    databaseId: 1,
+    login: 'tester',
+    issueComments: {
+      totalCount: nodes.length,
+      pageInfo: { hasPreviousPage: hasPrevious, startCursor },
+      nodes: nodes.map((n) => ({
+        createdAt: n.createdAt,
+        repository: { id: 'R_a', databaseId: 1, nameWithOwner: 'org/a' },
+        issue: { id: 'I' },
+        pullRequest: null,
+      })),
+    },
+    contributionsCollection: {
+      totalCommitContributions: 0,
+      totalPullRequestContributions: 0,
+      totalIssueContributions: 0,
+      totalPullRequestReviewContributions: 0,
+      totalRepositoriesWithContributedCommits: 0,
+      totalRepositoriesWithContributedPullRequests: 0,
+      totalRepositoriesWithContributedIssues: 0,
+      totalRepositoriesWithContributedPullRequestReviews: 0,
+      commitContributionsByRepository: [],
+      pullRequestContributionsByRepository: [],
+      issueContributionsByRepository: [],
+      pullRequestReviewContributionsByRepository: [],
+    },
+  }) as unknown as UserNode;
+
+describe('paginateIssueComments', () => {
+  it('returns the embedded first page when there are no previous pages', async () => {
+    const user = userWithComments(
+      [{ createdAt: '2026-04-01T00:00:00Z' }],
+      null,
+      false,
+    );
+    const { client, calls } = mockClient([]);
+    const sinceMs = new Date('2026-01-01T00:00:00Z').getTime();
+    const out = await paginateIssueComments(client, 'tester', user, sinceMs);
+    expect(out.pagesFetched).toBe(1);
+    expect(out.nodes).toHaveLength(1);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('halts when the oldest node falls below the window boundary', async () => {
+    const sinceMs = new Date('2026-01-01T00:00:00Z').getTime();
+    const user = userWithComments(
+      [{ createdAt: '2025-12-01T00:00:00Z' }],
+      'cursor1',
+      true,
+    );
+    const { client, calls } = mockClient([]);
+    const out = await paginateIssueComments(client, 'tester', user, sinceMs);
+    expect(out.pagesFetched).toBe(1);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('walks pages until previous-page is false', async () => {
+    const sinceMs = new Date('2026-01-01T00:00:00Z').getTime();
+    const user = userWithComments(
+      [{ createdAt: '2026-04-01T00:00:00Z' }],
+      'cursor1',
+      true,
+    );
+    const { client, calls } = mockClient([
+      {
+        user: {
+          issueComments: {
+            totalCount: 2,
+            pageInfo: { hasPreviousPage: true, startCursor: 'cursor2' },
+            nodes: [
+              {
+                createdAt: '2026-03-01T00:00:00Z',
+                repository: {
+                  id: 'R_a',
+                  databaseId: 1,
+                  nameWithOwner: 'org/a',
+                },
+                issue: { id: 'I' },
+                pullRequest: null,
+              },
+            ],
+          },
+        },
+      },
+      {
+        user: {
+          issueComments: {
+            totalCount: 3,
+            pageInfo: { hasPreviousPage: false, startCursor: null },
+            nodes: [
+              {
+                createdAt: '2026-02-01T00:00:00Z',
+                repository: {
+                  id: 'R_a',
+                  databaseId: 1,
+                  nameWithOwner: 'org/a',
+                },
+                issue: { id: 'I' },
+                pullRequest: null,
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    const out = await paginateIssueComments(client, 'tester', user, sinceMs);
+    expect(out.pagesFetched).toBe(3);
+    expect(out.nodes).toHaveLength(3);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('halts on cursor stagnation (server returns same cursor twice)', async () => {
+    const sinceMs = new Date('2026-01-01T00:00:00Z').getTime();
+    const user = userWithComments(
+      [{ createdAt: '2026-04-01T00:00:00Z' }],
+      'stuck',
+      true,
+    );
+    const { client, calls } = mockClient([
+      {
+        user: {
+          issueComments: {
+            totalCount: 2,
+            pageInfo: { hasPreviousPage: true, startCursor: 'stuck' },
+            nodes: [
+              {
+                createdAt: '2026-03-01T00:00:00Z',
+                repository: {
+                  id: 'R_a',
+                  databaseId: 1,
+                  nameWithOwner: 'org/a',
+                },
+                issue: { id: 'I' },
+                pullRequest: null,
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    const out = await paginateIssueComments(client, 'tester', user, sinceMs);
+    expect(calls).toHaveLength(1);
+    expect(out.nodes).toHaveLength(1);
+  });
+});
+
+describe('fetchPRReviewsInWindow', () => {
+  const reviewPage = (
+    nodes: Array<{ totalCount: number }>,
+    endCursor: string | null,
+    hasNext: boolean,
+  ) => ({
+    user: {
+      contributionsCollection: {
+        pullRequestReviewContributions: {
+          pageInfo: { hasNextPage: hasNext, endCursor },
+          nodes: nodes.map((n) => ({
+            pullRequestReview: {
+              createdAt: '2026-03-01T00:00:00Z',
+              repository: { id: 'R_a', databaseId: 1, nameWithOwner: 'org/a' },
+              comments: { totalCount: n.totalCount },
+            },
+          })),
+        },
+      },
+    },
+  });
+
+  it('halts after first page when hasNextPage is false', async () => {
+    const { client, calls } = mockClient([
+      reviewPage([{ totalCount: 5 }], null, false),
+    ]);
+    const out = await fetchPRReviewsInWindow(
+      client,
+      'tester',
+      '2025-10-29T00:00:00Z',
+    );
+    expect(out.pagesFetched).toBe(1);
+    expect(out.reviewsInWindow).toHaveLength(1);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('walks forward via after cursor across multiple pages', async () => {
+    const { client, calls } = mockClient([
+      reviewPage([{ totalCount: 1 }], 'p1', true),
+      reviewPage([{ totalCount: 2 }], 'p2', true),
+      reviewPage([{ totalCount: 3 }], null, false),
+    ]);
+    const out = await fetchPRReviewsInWindow(
+      client,
+      'tester',
+      '2025-10-29T00:00:00Z',
+    );
+    expect(out.pagesFetched).toBe(3);
+    expect(out.reviewsInWindow).toHaveLength(3);
+    expect(calls).toHaveLength(3);
+    expect(calls[1].variables).toMatchObject({ after: 'p1' });
+    expect(calls[2].variables).toMatchObject({ after: 'p2' });
+  });
+
+  it('halts on cursor stagnation', async () => {
+    const { client, calls } = mockClient([
+      reviewPage([{ totalCount: 1 }], 'stuck', true),
+      reviewPage([{ totalCount: 99 }], 'stuck', true),
+    ]);
+    const out = await fetchPRReviewsInWindow(
+      client,
+      'tester',
+      '2025-10-29T00:00:00Z',
+    );
+    expect(calls).toHaveLength(2);
+    expect(out.reviewsInWindow).toHaveLength(1);
+  });
+});

--- a/src/ingest/aggregate.ts
+++ b/src/ingest/aggregate.ts
@@ -1,0 +1,112 @@
+import type {
+  IssueCommentNode,
+  PullRequestReviewNode,
+  RepoMetadata,
+  UserNode,
+} from './graphql-types.js';
+import type { OverflowCounts } from './overflow.js';
+
+export interface RepoAggregate {
+  repoDatabaseId: number;
+  nameWithOwner: string;
+  description: string | null;
+  url: string;
+  forkCount: number;
+  stargazerCount: number;
+  primaryLanguage: string | null;
+  primaryLanguageColor: string | null;
+  licenseName: string | null;
+  licenseSpdx: string | null;
+  topics: string[];
+  commits: number;
+  pullRequests: number;
+  issues: number;
+  prReviews: number;
+  issueComments: number;
+  prComments: number;
+}
+
+export function aggregate(
+  user: UserNode,
+  commentsInWindow: IssueCommentNode[],
+  reviewsInWindow: PullRequestReviewNode[],
+  metadata: Map<string, RepoMetadata>,
+  overflowCounts: Map<string, OverflowCounts>,
+): Map<string, RepoAggregate> {
+  const perRepo = new Map<string, RepoAggregate>();
+  const c = user.contributionsCollection;
+
+  const ensure = (r: {
+    databaseId: number | null;
+    nameWithOwner: string;
+  }): RepoAggregate => {
+    const key = r.nameWithOwner;
+    let bucket = perRepo.get(key);
+    if (!bucket) {
+      const m = metadata.get(key);
+      const topics = (m?.repositoryTopics.nodes ?? [])
+        .map((n) => n?.topic?.name)
+        .filter((n): n is string => typeof n === 'string');
+      bucket = {
+        repoDatabaseId: r.databaseId ?? m?.databaseId ?? 0,
+        nameWithOwner: key,
+        description: m?.description ?? null,
+        url: m?.url ?? '',
+        forkCount: m?.forkCount ?? 0,
+        stargazerCount: m?.stargazerCount ?? 0,
+        primaryLanguage: m?.primaryLanguage?.name ?? null,
+        primaryLanguageColor: m?.primaryLanguage?.color ?? null,
+        licenseName: m?.licenseInfo?.name ?? null,
+        licenseSpdx: m?.licenseInfo?.spdxId ?? null,
+        topics,
+        commits: 0,
+        pullRequests: 0,
+        issues: 0,
+        prReviews: 0,
+        issueComments: 0,
+        prComments: 0,
+      };
+      perRepo.set(key, bucket);
+    }
+    return bucket;
+  };
+
+  for (const cb of c.commitContributionsByRepository) {
+    ensure(cb.repository).commits = cb.contributions.totalCount;
+  }
+  for (const cb of c.pullRequestContributionsByRepository) {
+    ensure(cb.repository).pullRequests = cb.contributions.totalCount;
+  }
+  for (const cb of c.issueContributionsByRepository) {
+    ensure(cb.repository).issues = cb.contributions.totalCount;
+  }
+  for (const cb of c.pullRequestReviewContributionsByRepository) {
+    ensure(cb.repository).prReviews = cb.contributions.totalCount;
+  }
+
+  for (const comment of commentsInWindow) {
+    if (!comment.repository) continue;
+    const bucket = ensure(comment.repository);
+    if (comment.pullRequest != null) bucket.prComments++;
+    else if (comment.issue != null) bucket.issueComments++;
+  }
+
+  for (const review of reviewsInWindow) {
+    if (!review.repository) continue;
+    ensure(review.repository).prComments += review.comments.totalCount;
+  }
+
+  for (const [nameWithOwner, counts] of overflowCounts) {
+    const m = metadata.get(nameWithOwner);
+    const bucket = ensure({
+      databaseId: m?.databaseId ?? null,
+      nameWithOwner,
+    });
+    if (counts.commits > 0) bucket.commits = counts.commits;
+    if (counts.prs > 0) bucket.pullRequests = counts.prs;
+    if (counts.issues > 0) bucket.issues = counts.issues;
+    if (counts.reviews > 0) bucket.prReviews = counts.reviews;
+  }
+
+  return perRepo;
+}

--- a/src/ingest/aggregate.ts
+++ b/src/ingest/aggregate.ts
@@ -34,30 +34,30 @@ export function aggregate(
   overflowCounts: Map<string, OverflowCounts>,
 ): Map<string, RepoAggregate> {
   const perRepo = new Map<string, RepoAggregate>();
-  const c = user.contributionsCollection;
+  const cc = user.contributionsCollection;
 
-  const ensure = (r: {
+  const ensure = (repo: {
     databaseId: number | null;
     nameWithOwner: string;
   }): RepoAggregate => {
-    const key = r.nameWithOwner;
+    const key = repo.nameWithOwner;
     let bucket = perRepo.get(key);
     if (!bucket) {
-      const m = metadata.get(key);
-      const topics = (m?.repositoryTopics.nodes ?? [])
+      const meta = metadata.get(key);
+      const topics = (meta?.repositoryTopics.nodes ?? [])
         .map((n) => n?.topic?.name)
-        .filter((n): n is string => typeof n === 'string');
+        .filter((name): name is string => typeof name === 'string');
       bucket = {
-        repoDatabaseId: r.databaseId ?? m?.databaseId ?? 0,
+        repoDatabaseId: repo.databaseId ?? meta?.databaseId ?? 0,
         nameWithOwner: key,
-        description: m?.description ?? null,
-        url: m?.url ?? '',
-        forkCount: m?.forkCount ?? 0,
-        stargazerCount: m?.stargazerCount ?? 0,
-        primaryLanguage: m?.primaryLanguage?.name ?? null,
-        primaryLanguageColor: m?.primaryLanguage?.color ?? null,
-        licenseName: m?.licenseInfo?.name ?? null,
-        licenseSpdx: m?.licenseInfo?.spdxId ?? null,
+        description: meta?.description ?? null,
+        url: meta?.url ?? '',
+        forkCount: meta?.forkCount ?? 0,
+        stargazerCount: meta?.stargazerCount ?? 0,
+        primaryLanguage: meta?.primaryLanguage?.name ?? null,
+        primaryLanguageColor: meta?.primaryLanguage?.color ?? null,
+        licenseName: meta?.licenseInfo?.name ?? null,
+        licenseSpdx: meta?.licenseInfo?.spdxId ?? null,
         topics,
         commits: 0,
         pullRequests: 0,
@@ -71,17 +71,17 @@ export function aggregate(
     return bucket;
   };
 
-  for (const cb of c.commitContributionsByRepository) {
-    ensure(cb.repository).commits = cb.contributions.totalCount;
+  for (const bucket of cc.commitContributionsByRepository) {
+    ensure(bucket.repository).commits = bucket.contributions.totalCount;
   }
-  for (const cb of c.pullRequestContributionsByRepository) {
-    ensure(cb.repository).pullRequests = cb.contributions.totalCount;
+  for (const bucket of cc.pullRequestContributionsByRepository) {
+    ensure(bucket.repository).pullRequests = bucket.contributions.totalCount;
   }
-  for (const cb of c.issueContributionsByRepository) {
-    ensure(cb.repository).issues = cb.contributions.totalCount;
+  for (const bucket of cc.issueContributionsByRepository) {
+    ensure(bucket.repository).issues = bucket.contributions.totalCount;
   }
-  for (const cb of c.pullRequestReviewContributionsByRepository) {
-    ensure(cb.repository).prReviews = cb.contributions.totalCount;
+  for (const bucket of cc.pullRequestReviewContributionsByRepository) {
+    ensure(bucket.repository).prReviews = bucket.contributions.totalCount;
   }
 
   for (const comment of commentsInWindow) {
@@ -97,9 +97,9 @@ export function aggregate(
   }
 
   for (const [nameWithOwner, counts] of overflowCounts) {
-    const m = metadata.get(nameWithOwner);
+    const meta = metadata.get(nameWithOwner);
     const bucket = ensure({
-      databaseId: m?.databaseId ?? null,
+      databaseId: meta?.databaseId ?? null,
       nameWithOwner,
     });
     if (counts.commits > 0) bucket.commits = counts.commits;

--- a/src/ingest/constants.ts
+++ b/src/ingest/constants.ts
@@ -1,0 +1,8 @@
+export const MIN_FORK_COUNT = 3;
+
+// GitHub's GraphQL caps. contributionsCollection's *ByRepository fields
+// return at most MAX_REPOSITORIES entries; pagination connections we use
+// fetch PAGE_SIZE nodes per call. Used both in queries and in overflow
+// detection in daily-contributions.ts.
+export const MAX_REPOSITORIES = 100;
+export const PAGE_SIZE = 100;

--- a/src/ingest/daily-contributions.ts
+++ b/src/ingest/daily-contributions.ts
@@ -1,0 +1,247 @@
+import type { GraphqlClient } from './graphql-client.js';
+import type {
+  FlatContributionsResponse,
+  FlatIssueContribEvent,
+  FlatPRContribEvent,
+  FlatReviewContribEvent,
+  IssueCommentNode,
+  PullRequestReviewNode,
+  RepoCommitsHistoryResponse,
+  RepoMetadata,
+  UserNode,
+} from './graphql-types.js';
+import {
+  FLAT_ISSUE_CONTRIBUTIONS_QUERY,
+  FLAT_PR_CONTRIBUTIONS_QUERY,
+  FLAT_REVIEW_CONTRIBUTIONS_QUERY,
+  REPO_COMMITS_HISTORY_QUERY,
+} from './graphql-queries.js';
+import type { RepoRef } from './overflow.js';
+import { MAX_REPOSITORIES, MIN_FORK_COUNT } from './constants.js';
+
+export interface OverflowCommitEvent {
+  nameWithOwner: string;
+  committedDate: string;
+}
+
+export interface OverflowCommitWalk {
+  events: OverflowCommitEvent[];
+  totalsByRepo: Map<string, number>;
+}
+
+/**
+ * Walks defaultBranchRef.history per overflow commit repo. Returns dated events
+ * (for the daily timeline) and per-repo totals (for the table). Both consumers
+ * share a single set of GraphQL calls — no duplicate fetching.
+ */
+export async function walkOverflowCommits(
+  client: GraphqlClient,
+  userGlobalId: string,
+  sinceISO: string,
+  repos: RepoRef[],
+): Promise<OverflowCommitWalk> {
+  const results = await Promise.all(
+    repos
+      .filter((repo) => repo.forkCount >= MIN_FORK_COUNT)
+      .map(async (repo) => {
+        const [owner, name] = repo.nameWithOwner.split('/');
+        if (!owner || !name) return null;
+        const repoEvents: OverflowCommitEvent[] = [];
+        let after: string | null = null;
+        while (true) {
+          const res: RepoCommitsHistoryResponse =
+            await client.call<RepoCommitsHistoryResponse>(
+              REPO_COMMITS_HISTORY_QUERY,
+              { owner, name, since: sinceISO, authorId: userGlobalId, after },
+            );
+          const history = res.repository?.defaultBranchRef?.target?.history;
+          if (!history) break;
+          for (const commit of history.nodes) {
+            repoEvents.push({
+              nameWithOwner: repo.nameWithOwner,
+              committedDate: commit.committedDate,
+            });
+          }
+          if (!history.pageInfo.hasNextPage) break;
+          if (after !== null && history.pageInfo.endCursor === after) break;
+          after = history.pageInfo.endCursor;
+        }
+        return { nameWithOwner: repo.nameWithOwner, repoEvents };
+      }),
+  );
+
+  const events: OverflowCommitEvent[] = [];
+  const totalsByRepo = new Map<string, number>();
+  for (const result of results) {
+    if (!result || result.repoEvents.length === 0) continue;
+    for (const ev of result.repoEvents) events.push(ev);
+    totalsByRepo.set(result.nameWithOwner, result.repoEvents.length);
+  }
+  return { events, totalsByRepo };
+}
+
+export interface ComputeDailyOptions {
+  client: GraphqlClient;
+  login: string;
+  sinceISO: string;
+  user: UserNode;
+  overflowCommitEvents: OverflowCommitEvent[];
+  reviewsInWindow: PullRequestReviewNode[];
+  commentsInWindow: IssueCommentNode[];
+  metadata: Map<string, RepoMetadata>;
+}
+
+export async function computeOssDailyContributions(
+  opts: ComputeDailyOptions,
+): Promise<Map<string, number>> {
+  const {
+    client,
+    login,
+    sinceISO,
+    user,
+    overflowCommitEvents,
+    reviewsInWindow,
+    commentsInWindow,
+    metadata,
+  } = opts;
+  const counts = new Map<string, number>();
+  const addToDay = (isoTimestamp: string, by = 1) => {
+    const day = isoTimestamp.slice(0, 10);
+    counts.set(day, (counts.get(day) || 0) + by);
+  };
+  const isOss = (nameWithOwner: string) => {
+    const m = metadata.get(nameWithOwner);
+    return !!m && m.forkCount >= MIN_FORK_COUNT;
+  };
+
+  const cc = user.contributionsCollection;
+
+  // Commits — bucketed (no flat list exists on contributionsCollection)
+  for (const bucket of cc.commitContributionsByRepository) {
+    if (!isOss(bucket.repository.nameWithOwner)) continue;
+    for (const ev of bucket.contributions.nodes) addToDay(ev.occurredAt, ev.commitCount);
+  }
+  // Commits in overflow repos (>100 cap): pre-walked by walkOverflowCommits()
+  // so the table and graph share a single fetch.
+  for (const ev of overflowCommitEvents) addToDay(ev.committedDate);
+
+  await Promise.all([
+    flatOrBucketed<FlatPRContribEvent>(
+      cc.pullRequestContributionsByRepository,
+      cc.totalRepositoriesWithContributedPullRequests,
+      client,
+      FLAT_PR_CONTRIBUTIONS_QUERY,
+      'pullRequestContributions',
+      login,
+      sinceISO,
+      isOss,
+      addToDay,
+      (ev) => ev.pullRequest?.repository,
+    ),
+    flatOrBucketed<FlatIssueContribEvent>(
+      cc.issueContributionsByRepository,
+      cc.totalRepositoriesWithContributedIssues,
+      client,
+      FLAT_ISSUE_CONTRIBUTIONS_QUERY,
+      'issueContributions',
+      login,
+      sinceISO,
+      isOss,
+      addToDay,
+      (ev) => ev.issue?.repository,
+    ),
+    flatOrBucketed<FlatReviewContribEvent>(
+      cc.pullRequestReviewContributionsByRepository,
+      cc.totalRepositoriesWithContributedPullRequestReviews,
+      client,
+      FLAT_REVIEW_CONTRIBUTIONS_QUERY,
+      'pullRequestReviewContributions',
+      login,
+      sinceISO,
+      isOss,
+      addToDay,
+      (ev) => ev.pullRequestReview?.repository,
+    ),
+  ]);
+
+  // Inline review comments (table also counts these in prComments)
+  for (const review of reviewsInWindow) {
+    if (!isOss(review.repository.nameWithOwner)) continue;
+    const inlineCount = review.comments?.totalCount ?? 0;
+    if (inlineCount > 0) addToDay(review.createdAt, inlineCount);
+  }
+
+  // Issue + PR conversation comments
+  for (const comment of commentsInWindow) {
+    if (!isOss(comment.repository.nameWithOwner)) continue;
+    addToDay(comment.createdAt);
+  }
+
+  return counts;
+}
+
+async function flatOrBucketed<TFlatNode extends { occurredAt: string }>(
+  buckets: Array<{
+    repository: { nameWithOwner: string };
+    contributions: {
+      pageInfo: { hasNextPage: boolean };
+      nodes: Array<{ occurredAt: string }>;
+    };
+  }>,
+  totalRepos: number,
+  client: GraphqlClient,
+  flatQuery: string,
+  field: string,
+  login: string,
+  sinceISO: string,
+  isOss: (n: string) => boolean,
+  addToDay: (iso: string, by?: number) => void,
+  flatRepoOf: (
+    ev: TFlatNode,
+  ) => { nameWithOwner: string; forkCount: number } | undefined,
+): Promise<void> {
+  const overflow =
+    totalRepos > MAX_REPOSITORIES ||
+    buckets.some((b) => b.contributions.pageInfo.hasNextPage);
+  if (overflow) {
+    const flat = await fetchAllFlat<TFlatNode>(
+      client,
+      flatQuery,
+      field,
+      login,
+      sinceISO,
+    );
+    for (const ev of flat) {
+      const repo = flatRepoOf(ev);
+      if (repo && repo.forkCount >= MIN_FORK_COUNT) addToDay(ev.occurredAt);
+    }
+    return;
+  }
+  for (const bucket of buckets) {
+    if (!isOss(bucket.repository.nameWithOwner)) continue;
+    for (const ev of bucket.contributions.nodes) addToDay(ev.occurredAt);
+  }
+}
+
+async function fetchAllFlat<TNode>(
+  client: GraphqlClient,
+  query: string,
+  field: string,
+  login: string,
+  sinceISO: string,
+): Promise<TNode[]> {
+  const out: TNode[] = [];
+  let after: string | null = null;
+  while (true) {
+    const res: FlatContributionsResponse<TNode> = await client.call<
+      FlatContributionsResponse<TNode>
+    >(query, { login, since: sinceISO, after });
+    const conn = res.user?.contributionsCollection?.[field];
+    if (!conn) break;
+    for (const n of conn.nodes) out.push(n);
+    if (!conn.pageInfo.hasNextPage) break;
+    if (after !== null && conn.pageInfo.endCursor === after) break;
+    after = conn.pageInfo.endCursor;
+  }
+  return out;
+}

--- a/src/ingest/graphql-client.ts
+++ b/src/ingest/graphql-client.ts
@@ -1,0 +1,51 @@
+import type { GraphqlErrorBody } from './graphql-types.js';
+
+const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
+const USER_AGENT = 'maakaf-friends-activity/1.0';
+const MAX_ATTEMPTS = 3;
+
+export class GraphqlClient {
+  constructor(private readonly token: string) {}
+
+  async call<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+    let res: Response | undefined;
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        res = await fetch(GITHUB_GRAPHQL_URL, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${this.token}`,
+            'Content-Type': 'application/json',
+            'User-Agent': USER_AGENT,
+          },
+          body: JSON.stringify({ query, variables }),
+        });
+        if (res.ok) break;
+        if (res.status < 500 || attempt === MAX_ATTEMPTS) break;
+      } catch (e) {
+        lastErr = e;
+        if (attempt === MAX_ATTEMPTS) throw e;
+      }
+      await new Promise((r) => setTimeout(r, 500 * attempt));
+    }
+    if (!res) {
+      if (lastErr instanceof Error) throw lastErr;
+      throw new Error('GitHub GraphQL: no response');
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(
+        `GitHub GraphQL HTTP ${res.status} ${res.statusText}${text ? ` — ${text.slice(0, 200)}` : ''}`,
+      );
+    }
+
+    const body = (await res.json()) as { data: T } & Partial<GraphqlErrorBody>;
+    if (body.errors && body.errors.length > 0) {
+      const msgs = body.errors.map((e) => e.message).join('; ');
+      throw new Error(`GitHub GraphQL error: ${msgs}`);
+    }
+    return body.data;
+  }
+}

--- a/src/ingest/graphql-ingest.service.ts
+++ b/src/ingest/graphql-ingest.service.ts
@@ -1,0 +1,285 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import type { UserActivityResponse } from './graphql-types.js';
+import { USER_ACTIVITY_QUERY } from './graphql-queries.js';
+import { GraphqlClient } from './graphql-client.js';
+import { paginateIssueComments, fetchPRReviewsInWindow } from './pagination.js';
+import { fetchRepoMetadata } from './metadata.js';
+import {
+  paginateReposContributedTo,
+  fetchOverflowCounts,
+  type ContributionType,
+  type OverflowCounts,
+  type RepoRef,
+} from './overflow.js';
+import { aggregate } from './aggregate.js';
+import {
+  upsertUserProfile,
+  upsertRepositories,
+  replaceUserActivity,
+  markUserReady,
+  markUserFailed,
+} from './persistence.js';
+
+const DEFAULT_WINDOW_DAYS = 180;
+const DEFAULT_CONCURRENCY = 30;
+
+export interface IngestUserResult {
+  login: string;
+  status: 'ready' | 'failed' | 'not_found';
+  reposTouched: number;
+  rateLimitCost: number;
+  rateLimitRemaining: number;
+  elapsedMs: number;
+  commentPagesFetched: number;
+  commentsInWindow: number;
+  error?: string;
+}
+
+@Injectable()
+export class GraphqlIngestService {
+  private readonly logger = new Logger(GraphqlIngestService.name);
+  private readonly client: GraphqlClient;
+
+  constructor(@InjectDataSource() private readonly ds: DataSource) {
+    const token = process.env.GITHUB_TOKEN;
+    if (!token) {
+      throw new Error('GITHUB_TOKEN environment variable is required');
+    }
+    this.client = new GraphqlClient(token);
+  }
+
+  async ingestUsers(
+    logins: string[],
+    windowDays = DEFAULT_WINDOW_DAYS,
+    concurrency = DEFAULT_CONCURRENCY,
+  ): Promise<IngestUserResult[]> {
+    const results: IngestUserResult[] = new Array<IngestUserResult>(
+      logins.length,
+    );
+    let cursor = 0;
+    const worker = async (): Promise<void> => {
+      while (true) {
+        const i = cursor++;
+        if (i >= logins.length) return;
+        results[i] = await this.ingestUser(logins[i], windowDays);
+      }
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(concurrency, logins.length) }, () =>
+        worker(),
+      ),
+    );
+    return results;
+  }
+
+  async ingestUser(
+    login: string,
+    windowDays = DEFAULT_WINDOW_DAYS,
+  ): Promise<IngestUserResult> {
+    const start = Date.now();
+    const sinceMs = Date.now() - windowDays * 86_400_000;
+    const since = new Date(sinceMs).toISOString();
+
+    try {
+      this.logger.log(`🔄 Ingesting ${login} (window=${windowDays}d)`);
+
+      const mainP = this.client.call<UserActivityResponse>(
+        USER_ACTIVITY_QUERY,
+        {
+          login,
+          since,
+        },
+      );
+      const reviewsP = fetchPRReviewsInWindow(this.client, login, since);
+
+      const primary = await mainP;
+      if (!primary.user) {
+        this.logger.warn(`⚠️ User '${login}' not found on GitHub`);
+        return {
+          login,
+          status: 'not_found',
+          reposTouched: 0,
+          rateLimitCost: primary.rateLimit?.cost ?? 0,
+          rateLimitRemaining: primary.rateLimit?.remaining ?? -1,
+          elapsedMs: Date.now() - start,
+          commentPagesFetched: 1,
+          commentsInWindow: 0,
+        };
+      }
+      const user = primary.user;
+      const c = user.contributionsCollection;
+
+      const initialIds = new Set<string>();
+      const knownIdsByType: Record<ContributionType, Set<string>> = {
+        COMMIT: new Set(),
+        PULL_REQUEST: new Set(),
+        ISSUE: new Set(),
+        PULL_REQUEST_REVIEW: new Set(),
+      };
+      for (const e of c.commitContributionsByRepository) {
+        initialIds.add(e.repository.id);
+        knownIdsByType.COMMIT.add(e.repository.id);
+      }
+      for (const e of c.pullRequestContributionsByRepository) {
+        initialIds.add(e.repository.id);
+        knownIdsByType.PULL_REQUEST.add(e.repository.id);
+      }
+      for (const e of c.issueContributionsByRepository) {
+        initialIds.add(e.repository.id);
+        knownIdsByType.ISSUE.add(e.repository.id);
+      }
+      for (const e of c.pullRequestReviewContributionsByRepository) {
+        initialIds.add(e.repository.id);
+        knownIdsByType.PULL_REQUEST_REVIEW.add(e.repository.id);
+      }
+      for (const cm of user.issueComments.nodes) {
+        if (cm.repository?.id) initialIds.add(cm.repository.id);
+      }
+
+      const overflowTypes: ContributionType[] = [];
+      if (
+        c.totalRepositoriesWithContributedCommits > knownIdsByType.COMMIT.size
+      )
+        overflowTypes.push('COMMIT');
+      if (
+        c.totalRepositoriesWithContributedPullRequests >
+        knownIdsByType.PULL_REQUEST.size
+      )
+        overflowTypes.push('PULL_REQUEST');
+      if (c.totalRepositoriesWithContributedIssues > knownIdsByType.ISSUE.size)
+        overflowTypes.push('ISSUE');
+      if (
+        c.totalRepositoriesWithContributedPullRequestReviews >
+        knownIdsByType.PULL_REQUEST_REVIEW.size
+      )
+        overflowTypes.push('PULL_REQUEST_REVIEW');
+
+      const overflowReposByType: Record<ContributionType, RepoRef[]> = {
+        COMMIT: [],
+        PULL_REQUEST: [],
+        ISSUE: [],
+        PULL_REQUEST_REVIEW: [],
+      };
+      const overflowRepoIds = new Set<string>();
+      if (overflowTypes.length > 0) {
+        this.logger.warn(
+          `↗️ ${login} has bucket overflow on ${overflowTypes.join(', ')} — paginating beyond 100`,
+        );
+        const lists = await Promise.all(
+          overflowTypes.map((t) =>
+            paginateReposContributedTo(this.client, login, t),
+          ),
+        );
+        overflowTypes.forEach((t, i) => {
+          for (const r of lists[i]) {
+            if (!knownIdsByType[t].has(r.id)) {
+              overflowReposByType[t].push(r);
+              overflowRepoIds.add(r.id);
+            }
+          }
+        });
+      }
+
+      const metadataP = fetchRepoMetadata(this.client, [
+        ...initialIds,
+        ...overflowRepoIds,
+      ]);
+      const commentsP = paginateIssueComments(
+        this.client,
+        login,
+        user,
+        sinceMs,
+      );
+      const overflowCountsP =
+        overflowRepoIds.size > 0
+          ? fetchOverflowCounts(
+              this.client,
+              login,
+              user.id,
+              since,
+              overflowReposByType,
+            )
+          : Promise.resolve(new Map<string, OverflowCounts>());
+
+      const [commentResult, reviewsResult, metadata, overflowCounts] =
+        await Promise.all([commentsP, reviewsP, metadataP, overflowCountsP]);
+      const { nodes: commentNodes, pagesFetched } = commentResult;
+
+      const commentsInWindow = commentNodes.filter(
+        (cm) => new Date(cm.createdAt).getTime() >= sinceMs,
+      );
+
+      const allKnownIds = new Set<string>([...initialIds, ...overflowRepoIds]);
+      const extraIds: string[] = [];
+      for (const cm of commentsInWindow) {
+        const id = cm.repository?.id;
+        if (id && !allKnownIds.has(id)) {
+          allKnownIds.add(id);
+          extraIds.push(id);
+        }
+      }
+      for (const r of reviewsResult.reviewsInWindow) {
+        const id = r.repository?.id;
+        if (id && !allKnownIds.has(id)) {
+          allKnownIds.add(id);
+          extraIds.push(id);
+        }
+      }
+      if (extraIds.length > 0) {
+        const extra = await fetchRepoMetadata(this.client, extraIds);
+        for (const [k, v] of extra) metadata.set(k, v);
+      }
+
+      const perRepo = aggregate(
+        user,
+        commentsInWindow,
+        reviewsResult.reviewsInWindow,
+        metadata,
+        overflowCounts,
+      );
+
+      await this.ds.transaction(async (tx) => {
+        await upsertUserProfile(tx, user);
+        await upsertRepositories(tx, perRepo);
+        await replaceUserActivity(tx, user, perRepo);
+        await markUserReady(tx, user);
+      });
+
+      this.logger.log(
+        `✅ ${login} ingested in ${Date.now() - start}ms — ` +
+          `${perRepo.size} repos, ${commentsInWindow.length} issue/PR comments ` +
+          `(${pagesFetched} pg), ` +
+          `${reviewsResult.reviewsInWindow.length} reviews ` +
+          `(${reviewsResult.pagesFetched} pg)`,
+      );
+
+      return {
+        login,
+        status: 'ready',
+        reposTouched: perRepo.size,
+        rateLimitCost: primary.rateLimit?.cost ?? 0,
+        rateLimitRemaining: primary.rateLimit?.remaining ?? -1,
+        elapsedMs: Date.now() - start,
+        commentPagesFetched: pagesFetched,
+        commentsInWindow: commentsInWindow.length,
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.error(`❌ Failed to ingest ${login}: ${msg}`);
+      await markUserFailed(this.ds, login, msg).catch(() => {});
+      return {
+        login,
+        status: 'failed',
+        reposTouched: 0,
+        rateLimitCost: 0,
+        rateLimitRemaining: -1,
+        elapsedMs: Date.now() - start,
+        commentPagesFetched: 0,
+        commentsInWindow: 0,
+        error: msg,
+      };
+    }
+  }
+}

--- a/src/ingest/graphql-ingest.service.ts
+++ b/src/ingest/graphql-ingest.service.ts
@@ -1,6 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectDataSource } from '@nestjs/typeorm';
-import { DataSource } from 'typeorm';
 import type { UserActivityResponse } from './graphql-types.js';
 import { USER_ACTIVITY_QUERY } from './graphql-queries.js';
 import { GraphqlClient } from './graphql-client.js';
@@ -13,36 +11,53 @@ import {
   type OverflowCounts,
   type RepoRef,
 } from './overflow.js';
+import { MIN_FORK_COUNT } from './constants.js';
 import { aggregate } from './aggregate.js';
+import {
+  computeOssDailyContributions,
+  walkOverflowCommits,
+} from './daily-contributions.js';
 import {
   upsertUserProfile,
   upsertRepositories,
   replaceUserActivity,
+  replaceUserDailyContributions,
   markUserReady,
-  markUserFailed,
 } from './persistence.js';
+import type { RepoAggregate } from './aggregate.js';
+import type { UserNode } from './graphql-types.js';
 
 const DEFAULT_WINDOW_DAYS = 180;
-const DEFAULT_CONCURRENCY = 30;
 
-export interface IngestUserResult {
-  login: string;
-  status: 'ready' | 'failed' | 'not_found';
-  reposTouched: number;
-  rateLimitCost: number;
-  rateLimitRemaining: number;
-  elapsedMs: number;
-  commentPagesFetched: number;
-  commentsInWindow: number;
-  error?: string;
-}
+export type FetchedUser =
+  | {
+      status: 'ready';
+      login: string;
+      user: UserNode;
+      perRepo: Map<string, RepoAggregate>;
+      dailyCounts: Map<string, number>;
+      reposTouched: number;
+      rateLimitCost: number;
+      rateLimitRemaining: number;
+      elapsedMs: number;
+      commentPagesFetched: number;
+      commentsInWindow: number;
+    }
+  | {
+      status: 'failed' | 'not_found';
+      login: string;
+      error?: string;
+      rateLimitCost: number;
+      rateLimitRemaining: number;
+      elapsedMs: number;
+    };
 
 @Injectable()
 export class GraphqlIngestService {
   private readonly logger = new Logger(GraphqlIngestService.name);
   private readonly client: GraphqlClient;
 
-  constructor(@InjectDataSource() private readonly ds: DataSource) {
+  constructor() {
     const token = process.env.GITHUB_TOKEN;
     if (!token) {
       throw new Error('GITHUB_TOKEN environment variable is required');
@@ -50,66 +65,33 @@ export class GraphqlIngestService {
     this.client = new GraphqlClient(token);
   }
 
-  async ingestUsers(
-    logins: string[],
-    windowDays = DEFAULT_WINDOW_DAYS,
-    concurrency = DEFAULT_CONCURRENCY,
-  ): Promise<IngestUserResult[]> {
-    const results: IngestUserResult[] = new Array<IngestUserResult>(
-      logins.length,
-    );
-    let cursor = 0;
-    const worker = async (): Promise<void> => {
-      while (true) {
-        const i = cursor++;
-        if (i >= logins.length) return;
-        results[i] = await this.ingestUser(logins[i], windowDays);
-      }
-    };
-    await Promise.all(
-      Array.from({ length: Math.min(concurrency, logins.length) }, () =>
-        worker(),
-      ),
-    );
-    return results;
-  }
-
-  async ingestUser(
+  async fetchUser(
     login: string,
     windowDays = DEFAULT_WINDOW_DAYS,
-  ): Promise<IngestUserResult> {
+  ): Promise<FetchedUser> {
     const start = Date.now();
     const sinceMs = Date.now() - windowDays * 86_400_000;
     const since = new Date(sinceMs).toISOString();
 
     try {
-      this.logger.log(`🔄 Ingesting ${login} (window=${windowDays}d)`);
+      this.logger.log(`🔄 Fetching ${login} (window=${windowDays}d)`);
 
-      const mainP = this.client.call<UserActivityResponse>(
-        USER_ACTIVITY_QUERY,
-        {
-          login,
-          since,
-        },
-      );
+      const mainP = this.client.call<UserActivityResponse>(USER_ACTIVITY_QUERY, { login, since });
       const reviewsP = fetchPRReviewsInWindow(this.client, login, since);
 
       const primary = await mainP;
       if (!primary.user) {
         this.logger.warn(`⚠️ User '${login}' not found on GitHub`);
         return {
-          login,
           status: 'not_found',
-          reposTouched: 0,
+          login,
           rateLimitCost: primary.rateLimit?.cost ?? 0,
           rateLimitRemaining: primary.rateLimit?.remaining ?? -1,
           elapsedMs: Date.now() - start,
-          commentPagesFetched: 1,
-          commentsInWindow: 0,
         };
       }
       const user = primary.user;
-      const c = user.contributionsCollection;
+      const contributions = user.contributionsCollection;
 
       const initialIds = new Set<string>();
       const knownIdsByType: Record<ContributionType, Set<string>> = {
@@ -118,42 +100,34 @@ export class GraphqlIngestService {
         ISSUE: new Set(),
         PULL_REQUEST_REVIEW: new Set(),
       };
-      for (const e of c.commitContributionsByRepository) {
-        initialIds.add(e.repository.id);
-        knownIdsByType.COMMIT.add(e.repository.id);
+      for (const bucket of contributions.commitContributionsByRepository) {
+        initialIds.add(bucket.repository.id);
+        knownIdsByType.COMMIT.add(bucket.repository.id);
       }
-      for (const e of c.pullRequestContributionsByRepository) {
-        initialIds.add(e.repository.id);
-        knownIdsByType.PULL_REQUEST.add(e.repository.id);
+      for (const bucket of contributions.pullRequestContributionsByRepository) {
+        initialIds.add(bucket.repository.id);
+        knownIdsByType.PULL_REQUEST.add(bucket.repository.id);
       }
-      for (const e of c.issueContributionsByRepository) {
-        initialIds.add(e.repository.id);
-        knownIdsByType.ISSUE.add(e.repository.id);
+      for (const bucket of contributions.issueContributionsByRepository) {
+        initialIds.add(bucket.repository.id);
+        knownIdsByType.ISSUE.add(bucket.repository.id);
       }
-      for (const e of c.pullRequestReviewContributionsByRepository) {
-        initialIds.add(e.repository.id);
-        knownIdsByType.PULL_REQUEST_REVIEW.add(e.repository.id);
+      for (const bucket of contributions.pullRequestReviewContributionsByRepository) {
+        initialIds.add(bucket.repository.id);
+        knownIdsByType.PULL_REQUEST_REVIEW.add(bucket.repository.id);
       }
-      for (const cm of user.issueComments.nodes) {
-        if (cm.repository?.id) initialIds.add(cm.repository.id);
+      for (const comment of user.issueComments.nodes) {
+        if (comment.repository?.id) initialIds.add(comment.repository.id);
       }
 
       const overflowTypes: ContributionType[] = [];
-      if (
-        c.totalRepositoriesWithContributedCommits > knownIdsByType.COMMIT.size
-      )
+      if (contributions.totalRepositoriesWithContributedCommits > knownIdsByType.COMMIT.size)
         overflowTypes.push('COMMIT');
-      if (
-        c.totalRepositoriesWithContributedPullRequests >
-        knownIdsByType.PULL_REQUEST.size
-      )
+      if (contributions.totalRepositoriesWithContributedPullRequests > knownIdsByType.PULL_REQUEST.size)
         overflowTypes.push('PULL_REQUEST');
-      if (c.totalRepositoriesWithContributedIssues > knownIdsByType.ISSUE.size)
+      if (contributions.totalRepositoriesWithContributedIssues > knownIdsByType.ISSUE.size)
         overflowTypes.push('ISSUE');
-      if (
-        c.totalRepositoriesWithContributedPullRequestReviews >
-        knownIdsByType.PULL_REQUEST_REVIEW.size
-      )
+      if (contributions.totalRepositoriesWithContributedPullRequestReviews > knownIdsByType.PULL_REQUEST_REVIEW.size)
         overflowTypes.push('PULL_REQUEST_REVIEW');
 
       const overflowReposByType: Record<ContributionType, RepoRef[]> = {
@@ -168,13 +142,11 @@ export class GraphqlIngestService {
           `↗️ ${login} has bucket overflow on ${overflowTypes.join(', ')} — paginating beyond 100`,
         );
         const lists = await Promise.all(
-          overflowTypes.map((t) =>
-            paginateReposContributedTo(this.client, login, t),
-          ),
+          overflowTypes.map((t) => paginateReposContributedTo(this.client, login, t)),
         );
         overflowTypes.forEach((t, i) => {
           for (const r of lists[i]) {
-            if (!knownIdsByType[t].has(r.id)) {
+            if (!knownIdsByType[t].has(r.id) && r.forkCount >= MIN_FORK_COUNT) {
               overflowReposByType[t].push(r);
               overflowRepoIds.add(r.id);
             }
@@ -182,31 +154,23 @@ export class GraphqlIngestService {
         });
       }
 
-      const metadataP = fetchRepoMetadata(this.client, [
-        ...initialIds,
-        ...overflowRepoIds,
+      const [commentResult, reviewsResult, metadata] = await Promise.all([
+        paginateIssueComments(this.client, login, user, sinceMs),
+        reviewsP,
+        fetchRepoMetadata(this.client, [...initialIds, ...overflowRepoIds]),
       ]);
-      const commentsP = paginateIssueComments(
-        this.client,
-        login,
-        user,
-        sinceMs,
-      );
-      const overflowCountsP =
+
+      const overflowCommitWalk =
+        overflowReposByType.COMMIT.length > 0
+          ? await walkOverflowCommits(this.client, user.id, since, overflowReposByType.COMMIT)
+          : { events: [], totalsByRepo: new Map<string, number>() };
+
+      const overflowCounts =
         overflowRepoIds.size > 0
-          ? fetchOverflowCounts(
-              this.client,
-              login,
-              user.id,
-              since,
-              overflowReposByType,
-            )
-          : Promise.resolve(new Map<string, OverflowCounts>());
+          ? await fetchOverflowCounts(this.client, login, user.id, since, overflowReposByType, overflowCommitWalk.totalsByRepo)
+          : new Map<string, OverflowCounts>();
 
-      const [commentResult, reviewsResult, metadata, overflowCounts] =
-        await Promise.all([commentsP, reviewsP, metadataP, overflowCountsP]);
       const { nodes: commentNodes, pagesFetched } = commentResult;
-
       const commentsInWindow = commentNodes.filter(
         (cm) => new Date(cm.createdAt).getTime() >= sinceMs,
       );
@@ -215,49 +179,43 @@ export class GraphqlIngestService {
       const extraIds: string[] = [];
       for (const cm of commentsInWindow) {
         const id = cm.repository?.id;
-        if (id && !allKnownIds.has(id)) {
-          allKnownIds.add(id);
-          extraIds.push(id);
-        }
+        if (id && !allKnownIds.has(id)) { allKnownIds.add(id); extraIds.push(id); }
       }
       for (const r of reviewsResult.reviewsInWindow) {
         const id = r.repository?.id;
-        if (id && !allKnownIds.has(id)) {
-          allKnownIds.add(id);
-          extraIds.push(id);
-        }
+        if (id && !allKnownIds.has(id)) { allKnownIds.add(id); extraIds.push(id); }
       }
       if (extraIds.length > 0) {
         const extra = await fetchRepoMetadata(this.client, extraIds);
         for (const [k, v] of extra) metadata.set(k, v);
       }
 
-      const perRepo = aggregate(
-        user,
-        commentsInWindow,
-        reviewsResult.reviewsInWindow,
-        metadata,
-        overflowCounts,
-      );
+      const perRepo = aggregate(user, commentsInWindow, reviewsResult.reviewsInWindow, metadata, overflowCounts);
 
-      await this.ds.transaction(async (tx) => {
-        await upsertUserProfile(tx, user);
-        await upsertRepositories(tx, perRepo);
-        await replaceUserActivity(tx, user, perRepo);
-        await markUserReady(tx, user);
+      const dailyCounts = await computeOssDailyContributions({
+        client: this.client,
+        login,
+        sinceISO: since,
+        user,
+        overflowCommitEvents: overflowCommitWalk.events,
+        reviewsInWindow: reviewsResult.reviewsInWindow,
+        commentsInWindow,
+        metadata,
       });
 
       this.logger.log(
-        `✅ ${login} ingested in ${Date.now() - start}ms — ` +
+        `✅ ${login} fetched in ${Date.now() - start}ms — ` +
           `${perRepo.size} repos, ${commentsInWindow.length} issue/PR comments ` +
-          `(${pagesFetched} pg), ` +
-          `${reviewsResult.reviewsInWindow.length} reviews ` +
+          `(${pagesFetched} pg), ${reviewsResult.reviewsInWindow.length} reviews ` +
           `(${reviewsResult.pagesFetched} pg)`,
       );
 
       return {
-        login,
         status: 'ready',
+        login,
+        user,
+        perRepo,
+        dailyCounts,
         reposTouched: perRepo.size,
         rateLimitCost: primary.rateLimit?.cost ?? 0,
         rateLimitRemaining: primary.rateLimit?.remaining ?? -1,
@@ -267,19 +225,16 @@ export class GraphqlIngestService {
       };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      this.logger.error(`❌ Failed to ingest ${login}: ${msg}`);
-      await markUserFailed(this.ds, login, msg).catch(() => {});
+      this.logger.error(`❌ Failed to fetch ${login}: ${msg}`);
       return {
-        login,
         status: 'failed',
-        reposTouched: 0,
+        login,
+        error: msg,
         rateLimitCost: 0,
         rateLimitRemaining: -1,
         elapsedMs: Date.now() - start,
-        commentPagesFetched: 0,
-        commentsInWindow: 0,
-        error: msg,
       };
     }
   }
+
 }

--- a/src/ingest/graphql-queries.ts
+++ b/src/ingest/graphql-queries.ts
@@ -1,0 +1,158 @@
+export const USER_ACTIVITY_QUERY = `
+query UserActivity($login: String!, $since: DateTime!) {
+  rateLimit { limit cost remaining resetAt }
+  user(login: $login) {
+    id databaseId login name avatarUrl url bio location company
+    websiteUrl twitterUsername createdAt
+    followers { totalCount }
+    following { totalCount }
+    repositories(privacy: PUBLIC) { totalCount }
+    contributionsCollection(from: $since) {
+      totalCommitContributions
+      totalPullRequestContributions
+      totalIssueContributions
+      totalPullRequestReviewContributions
+      totalRepositoriesWithContributedCommits
+      totalRepositoriesWithContributedPullRequests
+      totalRepositoriesWithContributedIssues
+      totalRepositoriesWithContributedPullRequestReviews
+      commitContributionsByRepository(maxRepositories: 100) {
+        repository { id databaseId nameWithOwner }
+        contributions { totalCount }
+      }
+      pullRequestContributionsByRepository(maxRepositories: 100) {
+        repository { id databaseId nameWithOwner }
+        contributions { totalCount }
+      }
+      issueContributionsByRepository(maxRepositories: 100) {
+        repository { id databaseId nameWithOwner }
+        contributions { totalCount }
+      }
+      pullRequestReviewContributionsByRepository(maxRepositories: 100) {
+        repository { id databaseId nameWithOwner }
+        contributions { totalCount }
+      }
+    }
+    issueComments(last: 100) {
+      totalCount
+      pageInfo { hasPreviousPage startCursor }
+      nodes {
+        createdAt
+        repository { id databaseId nameWithOwner }
+        issue { id }
+        pullRequest { id }
+      }
+    }
+  }
+}`;
+
+export const USER_COMMENTS_PAGE_QUERY = `
+query UserCommentsPage($login: String!, $before: String!) {
+  rateLimit { limit cost remaining resetAt }
+  user(login: $login) {
+    issueComments(last: 100, before: $before) {
+      totalCount
+      pageInfo { hasPreviousPage startCursor }
+      nodes {
+        createdAt
+        repository { id databaseId nameWithOwner }
+        issue { id }
+        pullRequest { id }
+      }
+    }
+  }
+}`;
+
+export const REPO_METADATA_QUERY = `
+query RepoMetadata($ids: [ID!]!) {
+  rateLimit { limit cost remaining resetAt }
+  nodes(ids: $ids) {
+    ... on Repository {
+      id
+      databaseId
+      nameWithOwner
+      description
+      url
+      forkCount
+      isPrivate
+      stargazerCount
+      primaryLanguage { name color }
+      licenseInfo { name spdxId }
+      repositoryTopics(first: 100) {
+        pageInfo { hasNextPage endCursor }
+        nodes { topic { name } }
+      }
+    }
+  }
+}`;
+
+export const REPO_TOPICS_PAGE_QUERY = `
+query RepoTopicsPage($id: ID!, $after: String!) {
+  rateLimit { limit cost remaining resetAt }
+  node(id: $id) {
+    ... on Repository {
+      repositoryTopics(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes { topic { name } }
+      }
+    }
+  }
+}`;
+
+export const REPOS_CONTRIBUTED_TO_QUERY = `
+query ReposContributedTo(
+  $login: String!,
+  $types: [RepositoryContributionType!],
+  $after: String
+) {
+  rateLimit { limit cost remaining resetAt }
+  user(login: $login) {
+    repositoriesContributedTo(
+      first: 100,
+      after: $after,
+      contributionTypes: $types,
+      includeUserRepositories: true
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes { id databaseId nameWithOwner }
+    }
+  }
+}`;
+
+export const USER_PR_REVIEWS_QUERY = `
+query UserPRReviews($login: String!, $since: DateTime!) {
+  rateLimit { limit cost remaining resetAt }
+  user(login: $login) {
+    contributionsCollection(from: $since) {
+      pullRequestReviewContributions(first: 100) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          pullRequestReview {
+            createdAt
+            repository { id databaseId nameWithOwner }
+            comments { totalCount }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+export const USER_PR_REVIEWS_PAGE_QUERY = `
+query UserPRReviewsPage($login: String!, $since: DateTime!, $after: String!) {
+  rateLimit { limit cost remaining resetAt }
+  user(login: $login) {
+    contributionsCollection(from: $since) {
+      pullRequestReviewContributions(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          pullRequestReview {
+            createdAt
+            repository { id databaseId nameWithOwner }
+            comments { totalCount }
+          }
+        }
+      }
+    }
+  }
+}`;

--- a/src/ingest/graphql-queries.ts
+++ b/src/ingest/graphql-queries.ts
@@ -1,3 +1,5 @@
+import { MAX_REPOSITORIES, PAGE_SIZE } from './constants.js';
+
 export const USER_ACTIVITY_QUERY = `
 query UserActivity($login: String!, $since: DateTime!) {
   rateLimit { limit cost remaining resetAt }
@@ -16,24 +18,40 @@ query UserActivity($login: String!, $since: DateTime!) {
       totalRepositoriesWithContributedPullRequests
       totalRepositoriesWithContributedIssues
       totalRepositoriesWithContributedPullRequestReviews
-      commitContributionsByRepository(maxRepositories: 100) {
+      commitContributionsByRepository(maxRepositories: ${MAX_REPOSITORIES}) {
         repository { id databaseId nameWithOwner }
-        contributions { totalCount }
+        contributions(first: ${PAGE_SIZE}) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes { occurredAt commitCount }
+        }
       }
-      pullRequestContributionsByRepository(maxRepositories: 100) {
+      pullRequestContributionsByRepository(maxRepositories: ${MAX_REPOSITORIES}) {
         repository { id databaseId nameWithOwner }
-        contributions { totalCount }
+        contributions(first: ${PAGE_SIZE}) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes { occurredAt }
+        }
       }
-      issueContributionsByRepository(maxRepositories: 100) {
+      issueContributionsByRepository(maxRepositories: ${MAX_REPOSITORIES}) {
         repository { id databaseId nameWithOwner }
-        contributions { totalCount }
+        contributions(first: ${PAGE_SIZE}) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes { occurredAt }
+        }
       }
-      pullRequestReviewContributionsByRepository(maxRepositories: 100) {
+      pullRequestReviewContributionsByRepository(maxRepositories: ${MAX_REPOSITORIES}) {
         repository { id databaseId nameWithOwner }
-        contributions { totalCount }
+        contributions(first: ${PAGE_SIZE}) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes { occurredAt }
+        }
       }
     }
-    issueComments(last: 100) {
+    issueComments(last: ${PAGE_SIZE}) {
       totalCount
       pageInfo { hasPreviousPage startCursor }
       nodes {
@@ -50,7 +68,7 @@ export const USER_COMMENTS_PAGE_QUERY = `
 query UserCommentsPage($login: String!, $before: String!) {
   rateLimit { limit cost remaining resetAt }
   user(login: $login) {
-    issueComments(last: 100, before: $before) {
+    issueComments(last: ${PAGE_SIZE}, before: $before) {
       totalCount
       pageInfo { hasPreviousPage startCursor }
       nodes {
@@ -78,7 +96,7 @@ query RepoMetadata($ids: [ID!]!) {
       stargazerCount
       primaryLanguage { name color }
       licenseInfo { name spdxId }
-      repositoryTopics(first: 100) {
+      repositoryTopics(first: ${PAGE_SIZE}) {
         pageInfo { hasNextPage endCursor }
         nodes { topic { name } }
       }
@@ -91,7 +109,7 @@ query RepoTopicsPage($id: ID!, $after: String!) {
   rateLimit { limit cost remaining resetAt }
   node(id: $id) {
     ... on Repository {
-      repositoryTopics(first: 100, after: $after) {
+      repositoryTopics(first: ${PAGE_SIZE}, after: $after) {
         pageInfo { hasNextPage endCursor }
         nodes { topic { name } }
       }
@@ -108,13 +126,13 @@ query ReposContributedTo(
   rateLimit { limit cost remaining resetAt }
   user(login: $login) {
     repositoriesContributedTo(
-      first: 100,
+      first: ${PAGE_SIZE},
       after: $after,
       contributionTypes: $types,
       includeUserRepositories: true
     ) {
       pageInfo { hasNextPage endCursor }
-      nodes { id databaseId nameWithOwner }
+      nodes { id databaseId nameWithOwner forkCount }
     }
   }
 }`;
@@ -124,7 +142,7 @@ query UserPRReviews($login: String!, $since: DateTime!) {
   rateLimit { limit cost remaining resetAt }
   user(login: $login) {
     contributionsCollection(from: $since) {
-      pullRequestReviewContributions(first: 100) {
+      pullRequestReviewContributions(first: ${PAGE_SIZE}) {
         pageInfo { hasNextPage endCursor }
         nodes {
           pullRequestReview {
@@ -138,12 +156,74 @@ query UserPRReviews($login: String!, $since: DateTime!) {
   }
 }`;
 
+export const REPO_COMMITS_HISTORY_QUERY = `
+query RepoCommitsHistory(
+  $owner: String!,
+  $name: String!,
+  $since: GitTimestamp!,
+  $authorId: ID!,
+  $after: String
+) {
+  rateLimit { limit cost remaining resetAt }
+  repository(owner: $owner, name: $name) {
+    defaultBranchRef {
+      target {
+        ... on Commit {
+          history(since: $since, author: { id: $authorId }, first: ${PAGE_SIZE}, after: $after) {
+            pageInfo { hasNextPage endCursor }
+            nodes { committedDate }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+export const FLAT_PR_CONTRIBUTIONS_QUERY = `
+query FlatPRContributions($login: String!, $since: DateTime!, $after: String) {
+  rateLimit { limit cost remaining resetAt }
+  user(login: $login) {
+    contributionsCollection(from: $since) {
+      pullRequestContributions(first: ${PAGE_SIZE}, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes { occurredAt pullRequest { repository { nameWithOwner forkCount } } }
+      }
+    }
+  }
+}`;
+
+export const FLAT_ISSUE_CONTRIBUTIONS_QUERY = `
+query FlatIssueContributions($login: String!, $since: DateTime!, $after: String) {
+  rateLimit { limit cost remaining resetAt }
+  user(login: $login) {
+    contributionsCollection(from: $since) {
+      issueContributions(first: ${PAGE_SIZE}, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes { occurredAt issue { repository { nameWithOwner forkCount } } }
+      }
+    }
+  }
+}`;
+
+export const FLAT_REVIEW_CONTRIBUTIONS_QUERY = `
+query FlatReviewContributions($login: String!, $since: DateTime!, $after: String) {
+  rateLimit { limit cost remaining resetAt }
+  user(login: $login) {
+    contributionsCollection(from: $since) {
+      pullRequestReviewContributions(first: ${PAGE_SIZE}, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes { occurredAt pullRequestReview { repository { nameWithOwner forkCount } } }
+      }
+    }
+  }
+}`;
+
 export const USER_PR_REVIEWS_PAGE_QUERY = `
 query UserPRReviewsPage($login: String!, $since: DateTime!, $after: String!) {
   rateLimit { limit cost remaining resetAt }
   user(login: $login) {
     contributionsCollection(from: $since) {
-      pullRequestReviewContributions(first: 100, after: $after) {
+      pullRequestReviewContributions(first: ${PAGE_SIZE}, after: $after) {
         pageInfo { hasNextPage endCursor }
         nodes {
           pullRequestReview {

--- a/src/ingest/graphql-types.ts
+++ b/src/ingest/graphql-types.ts
@@ -1,0 +1,142 @@
+export interface RateLimit {
+  limit: number;
+  cost: number;
+  remaining: number;
+  resetAt: string;
+}
+
+export interface RepositoryRef {
+  id: string;
+  databaseId: number | null;
+  nameWithOwner: string;
+}
+
+export interface RepositoryTopicsConnection {
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  nodes: Array<{ topic: { name: string } } | null>;
+}
+
+export interface RepoMetadata {
+  id: string;
+  databaseId: number | null;
+  nameWithOwner: string;
+  description: string | null;
+  url: string;
+  forkCount: number;
+  isPrivate: boolean;
+  stargazerCount: number;
+  primaryLanguage: { name: string; color: string | null } | null;
+  licenseInfo: { name: string; spdxId: string | null } | null;
+  repositoryTopics: RepositoryTopicsConnection;
+}
+
+export interface RepoTopicsPageResponse {
+  rateLimit: RateLimit | null;
+  node: { repositoryTopics: RepositoryTopicsConnection } | null;
+}
+
+export interface RepoMetadataResponse {
+  rateLimit: RateLimit | null;
+  nodes: Array<RepoMetadata | null>;
+}
+
+export interface ContributionsByRepo {
+  repository: RepositoryRef;
+  contributions: { totalCount: number };
+}
+
+export interface ContributionsCollection {
+  totalCommitContributions: number;
+  totalPullRequestContributions: number;
+  totalIssueContributions: number;
+  totalPullRequestReviewContributions: number;
+  totalRepositoriesWithContributedCommits: number;
+  totalRepositoriesWithContributedPullRequests: number;
+  totalRepositoriesWithContributedIssues: number;
+  totalRepositoriesWithContributedPullRequestReviews: number;
+  commitContributionsByRepository: ContributionsByRepo[];
+  pullRequestContributionsByRepository: ContributionsByRepo[];
+  issueContributionsByRepository: ContributionsByRepo[];
+  pullRequestReviewContributionsByRepository: ContributionsByRepo[];
+}
+
+export interface ReposContributedToConnection {
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  nodes: Array<{
+    id: string;
+    databaseId: number | null;
+    nameWithOwner: string;
+  } | null>;
+}
+
+export interface ReposContributedToResponse {
+  rateLimit: RateLimit | null;
+  user: { repositoriesContributedTo: ReposContributedToConnection } | null;
+}
+
+export interface IssueCommentNode {
+  createdAt: string;
+  repository: { id: string; databaseId: number | null; nameWithOwner: string };
+  issue: { id: string } | null;
+  pullRequest: { id: string } | null;
+}
+
+export interface IssueCommentsConnection {
+  totalCount: number;
+  pageInfo: { hasPreviousPage: boolean; startCursor: string | null };
+  nodes: IssueCommentNode[];
+}
+
+export interface UserNode {
+  id: string;
+  databaseId: number | null;
+  login: string;
+  name: string | null;
+  avatarUrl: string;
+  url: string;
+  bio: string | null;
+  location: string | null;
+  company: string | null;
+  websiteUrl: string | null;
+  twitterUsername: string | null;
+  createdAt: string;
+  followers: { totalCount: number };
+  following: { totalCount: number };
+  repositories: { totalCount: number };
+  contributionsCollection: ContributionsCollection;
+  issueComments: IssueCommentsConnection;
+}
+
+export interface UserActivityResponse {
+  rateLimit: RateLimit | null;
+  user: UserNode | null;
+}
+
+export interface UserCommentsPageResponse {
+  rateLimit: RateLimit | null;
+  user: { issueComments: IssueCommentsConnection } | null;
+}
+
+export interface PullRequestReviewNode {
+  createdAt: string;
+  repository: { id: string; databaseId: number | null; nameWithOwner: string };
+  comments: { totalCount: number };
+}
+
+export interface PullRequestReviewContributionsConnection {
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  nodes: Array<{ pullRequestReview: PullRequestReviewNode | null }>;
+}
+
+export interface UserPRReviewsResponse {
+  rateLimit: RateLimit | null;
+  user: {
+    contributionsCollection: {
+      pullRequestReviewContributions: PullRequestReviewContributionsConnection;
+    };
+  } | null;
+}
+
+export interface GraphqlErrorBody {
+  errors: Array<{ message: string; path?: string[]; extensions?: unknown }>;
+}

--- a/src/ingest/graphql-types.ts
+++ b/src/ingest/graphql-types.ts
@@ -40,9 +40,25 @@ export interface RepoMetadataResponse {
   nodes: Array<RepoMetadata | null>;
 }
 
-export interface ContributionsByRepo {
+export interface ContributionEvent {
+  occurredAt: string;
+}
+
+export interface CommitContributionEvent extends ContributionEvent {
+  commitCount: number;
+}
+
+export interface ContributionsConnection<TNode extends ContributionEvent> {
+  totalCount: number;
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  nodes: TNode[];
+}
+
+export interface ContributionsByRepo<
+  TNode extends ContributionEvent = ContributionEvent,
+> {
   repository: RepositoryRef;
-  contributions: { totalCount: number };
+  contributions: ContributionsConnection<TNode>;
 }
 
 export interface ContributionsCollection {
@@ -54,10 +70,56 @@ export interface ContributionsCollection {
   totalRepositoriesWithContributedPullRequests: number;
   totalRepositoriesWithContributedIssues: number;
   totalRepositoriesWithContributedPullRequestReviews: number;
-  commitContributionsByRepository: ContributionsByRepo[];
+  commitContributionsByRepository: ContributionsByRepo<CommitContributionEvent>[];
   pullRequestContributionsByRepository: ContributionsByRepo[];
   issueContributionsByRepository: ContributionsByRepo[];
   pullRequestReviewContributionsByRepository: ContributionsByRepo[];
+}
+
+interface FlatRepoRef {
+  nameWithOwner: string;
+  forkCount: number;
+}
+
+export type FlatPRContribEvent = {
+  occurredAt: string;
+  pullRequest: { repository: FlatRepoRef } | null;
+};
+
+export type FlatIssueContribEvent = {
+  occurredAt: string;
+  issue: { repository: FlatRepoRef } | null;
+};
+
+export type FlatReviewContribEvent = {
+  occurredAt: string;
+  pullRequestReview: { repository: FlatRepoRef } | null;
+};
+
+export interface RepoCommitsHistoryResponse {
+  rateLimit: RateLimit | null;
+  repository: {
+    defaultBranchRef: {
+      target: {
+        history: {
+          pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          nodes: Array<{ committedDate: string }>;
+        };
+      } | null;
+    } | null;
+  } | null;
+}
+
+export interface FlatContributionsResponse<TNode> {
+  rateLimit: RateLimit | null;
+  user: {
+    contributionsCollection: {
+      [key: string]: {
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        nodes: TNode[];
+      };
+    };
+  } | null;
 }
 
 export interface ReposContributedToConnection {
@@ -66,6 +128,7 @@ export interface ReposContributedToConnection {
     id: string;
     databaseId: number | null;
     nameWithOwner: string;
+    forkCount: number;
   } | null>;
 }
 

--- a/src/ingest/ingest.module.ts
+++ b/src/ingest/ingest.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { GraphqlIngestService } from './graphql-ingest.service.js';
+
+@Module({
+  providers: [GraphqlIngestService],
+  exports: [GraphqlIngestService],
+})
+export class IngestModule {}

--- a/src/ingest/metadata.ts
+++ b/src/ingest/metadata.ts
@@ -1,0 +1,59 @@
+import type { GraphqlClient } from './graphql-client.js';
+import type {
+  RepoMetadata,
+  RepoMetadataResponse,
+  RepoTopicsPageResponse,
+} from './graphql-types.js';
+import {
+  REPO_METADATA_QUERY,
+  REPO_TOPICS_PAGE_QUERY,
+} from './graphql-queries.js';
+
+const NODES_BATCH_SIZE = 100;
+
+export async function fetchRepoMetadata(
+  client: GraphqlClient,
+  ids: string[],
+): Promise<Map<string, RepoMetadata>> {
+  const map = new Map<string, RepoMetadata>();
+  if (ids.length === 0) return map;
+
+  for (let i = 0; i < ids.length; i += NODES_BATCH_SIZE) {
+    const chunk = ids.slice(i, i + NODES_BATCH_SIZE);
+    const res = await client.call<RepoMetadataResponse>(REPO_METADATA_QUERY, {
+      ids: chunk,
+    });
+    for (const n of res.nodes) {
+      if (n && n.nameWithOwner) map.set(n.nameWithOwner, n);
+    }
+  }
+
+  await Promise.all(
+    [...map.values()]
+      .filter((m) => m.repositoryTopics.pageInfo.hasNextPage)
+      .map((m) => paginateTopics(client, m)),
+  );
+
+  return map;
+}
+
+async function paginateTopics(
+  client: GraphqlClient,
+  meta: RepoMetadata,
+): Promise<void> {
+  let cursor = meta.repositoryTopics.pageInfo.endCursor;
+  let hasNext = meta.repositoryTopics.pageInfo.hasNextPage;
+  while (hasNext && cursor) {
+    const page = await client.call<RepoTopicsPageResponse>(
+      REPO_TOPICS_PAGE_QUERY,
+      { id: meta.id, after: cursor },
+    );
+    if (!page.node) break;
+    const conn = page.node.repositoryTopics;
+    const nextCursor = conn.pageInfo.endCursor;
+    if (nextCursor === cursor) break;
+    meta.repositoryTopics.nodes.push(...conn.nodes);
+    cursor = nextCursor;
+    hasNext = conn.pageInfo.hasNextPage;
+  }
+}

--- a/src/ingest/overflow.ts
+++ b/src/ingest/overflow.ts
@@ -14,6 +14,7 @@ export interface RepoRef {
   id: string;
   databaseId: number | null;
   nameWithOwner: string;
+  forkCount: number;
 }
 
 export interface OverflowCounts {
@@ -63,23 +64,32 @@ export async function fetchOverflowCounts(
     ISSUE: RepoRef[];
     PULL_REQUEST_REVIEW: RepoRef[];
   },
+  precomputedCommitTotals?: Map<string, number>,
 ): Promise<Map<string, OverflowCounts>> {
   const out = new Map<string, OverflowCounts>();
-  const ensure = (k: string) => {
-    let b = out.get(k);
-    if (!b) {
-      b = { commits: 0, prs: 0, issues: 0, reviews: 0 };
-      out.set(k, b);
+  const ensure = (nameWithOwner: string) => {
+    let bucket = out.get(nameWithOwner);
+    if (!bucket) {
+      bucket = { commits: 0, prs: 0, issues: 0, reviews: 0 };
+      out.set(nameWithOwner, bucket);
     }
-    return b;
+    return bucket;
   };
 
   type Job =
     | { kind: 'commit'; repo: { nameWithOwner: string } }
     | { kind: 'pr' | 'issue' | 'review'; repo: { nameWithOwner: string } };
 
+  if (precomputedCommitTotals) {
+    for (const [name, count] of precomputedCommitTotals) {
+      ensure(name).commits = count;
+    }
+  }
+
   const jobs: Job[] = [
-    ...overflow.COMMIT.map((r) => ({ kind: 'commit' as const, repo: r })),
+    ...(precomputedCommitTotals
+      ? []
+      : overflow.COMMIT.map((r) => ({ kind: 'commit' as const, repo: r }))),
     ...overflow.PULL_REQUEST.map((r) => ({ kind: 'pr' as const, repo: r })),
     ...overflow.ISSUE.map((r) => ({ kind: 'issue' as const, repo: r })),
     ...overflow.PULL_REQUEST_REVIEW.map((r) => ({

--- a/src/ingest/overflow.ts
+++ b/src/ingest/overflow.ts
@@ -1,0 +1,178 @@
+import type { GraphqlClient } from './graphql-client.js';
+import type { ReposContributedToResponse } from './graphql-types.js';
+import { REPOS_CONTRIBUTED_TO_QUERY } from './graphql-queries.js';
+
+const OVERFLOW_BATCH_SIZE = 25;
+
+export type ContributionType =
+  | 'COMMIT'
+  | 'PULL_REQUEST'
+  | 'ISSUE'
+  | 'PULL_REQUEST_REVIEW';
+
+export interface RepoRef {
+  id: string;
+  databaseId: number | null;
+  nameWithOwner: string;
+}
+
+export interface OverflowCounts {
+  commits: number;
+  prs: number;
+  issues: number;
+  reviews: number;
+}
+
+export async function paginateReposContributedTo(
+  client: GraphqlClient,
+  login: string,
+  contributionType: ContributionType,
+): Promise<RepoRef[]> {
+  const out: RepoRef[] = [];
+  let cursor: string | null = null;
+  let hasNext = true;
+  while (hasNext) {
+    const res: ReposContributedToResponse =
+      await client.call<ReposContributedToResponse>(
+        REPOS_CONTRIBUTED_TO_QUERY,
+        {
+          login,
+          types: [contributionType],
+          after: cursor,
+        },
+      );
+    if (!res.user) break;
+    const conn = res.user.repositoriesContributedTo;
+    const nextCursor = conn.pageInfo.endCursor;
+    if (cursor !== null && nextCursor === cursor) break;
+    for (const n of conn.nodes) if (n) out.push(n);
+    cursor = nextCursor;
+    hasNext = conn.pageInfo.hasNextPage;
+  }
+  return out;
+}
+
+export async function fetchOverflowCounts(
+  client: GraphqlClient,
+  login: string,
+  userGlobalId: string,
+  sinceISO: string,
+  overflow: {
+    COMMIT: RepoRef[];
+    PULL_REQUEST: RepoRef[];
+    ISSUE: RepoRef[];
+    PULL_REQUEST_REVIEW: RepoRef[];
+  },
+): Promise<Map<string, OverflowCounts>> {
+  const out = new Map<string, OverflowCounts>();
+  const ensure = (k: string) => {
+    let b = out.get(k);
+    if (!b) {
+      b = { commits: 0, prs: 0, issues: 0, reviews: 0 };
+      out.set(k, b);
+    }
+    return b;
+  };
+
+  type Job =
+    | { kind: 'commit'; repo: { nameWithOwner: string } }
+    | { kind: 'pr' | 'issue' | 'review'; repo: { nameWithOwner: string } };
+
+  const jobs: Job[] = [
+    ...overflow.COMMIT.map((r) => ({ kind: 'commit' as const, repo: r })),
+    ...overflow.PULL_REQUEST.map((r) => ({ kind: 'pr' as const, repo: r })),
+    ...overflow.ISSUE.map((r) => ({ kind: 'issue' as const, repo: r })),
+    ...overflow.PULL_REQUEST_REVIEW.map((r) => ({
+      kind: 'review' as const,
+      repo: r,
+    })),
+  ];
+  if (jobs.length === 0) return out;
+
+  for (let i = 0; i < jobs.length; i += OVERFLOW_BATCH_SIZE) {
+    const chunk = jobs.slice(i, i + OVERFLOW_BATCH_SIZE);
+    const fragments: string[] = [];
+    const variables: Record<string, unknown> = {};
+    const varDefs: string[] = [];
+    let usesSince = false;
+    let usesAuthorId = false;
+    const aliases: string[] = [];
+
+    chunk.forEach((job, idx) => {
+      const a = `${job.kind}${idx}`;
+      aliases.push(a);
+      if (job.kind === 'commit') {
+        usesSince = true;
+        usesAuthorId = true;
+        const [owner, name] = job.repo.nameWithOwner.split('/');
+        const ov = `${a}_owner`;
+        const nv = `${a}_name`;
+        variables[ov] = owner;
+        variables[nv] = name;
+        varDefs.push(`$${ov}: String!`, `$${nv}: String!`);
+        fragments.push(`
+          ${a}: repository(owner: $${ov}, name: $${nv}) {
+            defaultBranchRef {
+              target {
+                ... on Commit {
+                  history(since: $since, author: { id: $authorId }) { totalCount }
+                }
+              }
+            }
+          }`);
+      } else {
+        const qv = `${a}_q`;
+        const qualifier =
+          job.kind === 'pr'
+            ? `repo:${job.repo.nameWithOwner} author:${login} is:pr created:>=${sinceISO}`
+            : job.kind === 'issue'
+              ? `repo:${job.repo.nameWithOwner} author:${login} is:issue created:>=${sinceISO}`
+              : `repo:${job.repo.nameWithOwner} reviewed-by:${login} is:pr updated:>=${sinceISO}`;
+        variables[qv] = qualifier;
+        varDefs.push(`$${qv}: String!`);
+        fragments.push(`
+          ${a}: search(query: $${qv}, type: ISSUE, first: 0) { issueCount }`);
+      }
+    });
+
+    if (usesSince) {
+      variables.since = sinceISO;
+      varDefs.unshift(`$since: GitTimestamp!`);
+    }
+    if (usesAuthorId) {
+      variables.authorId = userGlobalId;
+      varDefs.unshift(`$authorId: ID!`);
+    }
+
+    const query = `query OverflowCounts(${varDefs.join(', ')}) {
+      rateLimit { limit cost remaining resetAt }
+      ${fragments.join('\n')}
+    }`;
+
+    const res: Record<string, unknown> = await client.call<
+      Record<string, unknown>
+    >(query, variables);
+
+    chunk.forEach((job, idx) => {
+      const a = aliases[idx];
+      if (job.kind === 'commit') {
+        const node = res[a] as {
+          defaultBranchRef: {
+            target: { history: { totalCount: number } } | null;
+          } | null;
+        } | null;
+        ensure(job.repo.nameWithOwner).commits =
+          node?.defaultBranchRef?.target?.history?.totalCount ?? 0;
+      } else {
+        const node = res[a] as { issueCount: number } | null;
+        const count = node?.issueCount ?? 0;
+        const bucket = ensure(job.repo.nameWithOwner);
+        if (job.kind === 'pr') bucket.prs = count;
+        else if (job.kind === 'issue') bucket.issues = count;
+        else bucket.reviews = count;
+      }
+    });
+  }
+
+  return out;
+}

--- a/src/ingest/pagination.ts
+++ b/src/ingest/pagination.ts
@@ -1,0 +1,83 @@
+import type { GraphqlClient } from './graphql-client.js';
+import type {
+  IssueCommentNode,
+  PullRequestReviewNode,
+  UserCommentsPageResponse,
+  UserNode,
+  UserPRReviewsResponse,
+} from './graphql-types.js';
+import {
+  USER_COMMENTS_PAGE_QUERY,
+  USER_PR_REVIEWS_PAGE_QUERY,
+  USER_PR_REVIEWS_QUERY,
+} from './graphql-queries.js';
+
+export async function paginateIssueComments(
+  client: GraphqlClient,
+  login: string,
+  user: UserNode,
+  sinceMs: number,
+): Promise<{ nodes: IssueCommentNode[]; pagesFetched: number }> {
+  let nodes: IssueCommentNode[] = user.issueComments.nodes;
+  let pagesFetched = 1;
+  let cursor = user.issueComments.pageInfo.startCursor;
+  let hasPrevious = user.issueComments.pageInfo.hasPreviousPage;
+
+  while (
+    hasPrevious &&
+    cursor &&
+    nodes.length > 0 &&
+    new Date(nodes[0].createdAt).getTime() >= sinceMs
+  ) {
+    const page = await client.call<UserCommentsPageResponse>(
+      USER_COMMENTS_PAGE_QUERY,
+      { login, before: cursor },
+    );
+    if (!page.user) break;
+    const nextCursor = page.user.issueComments.pageInfo.startCursor;
+    if (nextCursor === cursor) break;
+    nodes = [...page.user.issueComments.nodes, ...nodes];
+    cursor = nextCursor;
+    hasPrevious = page.user.issueComments.pageInfo.hasPreviousPage;
+    pagesFetched++;
+  }
+
+  return { nodes, pagesFetched };
+}
+
+export async function fetchPRReviewsInWindow(
+  client: GraphqlClient,
+  login: string,
+  since: string,
+): Promise<{ reviewsInWindow: PullRequestReviewNode[]; pagesFetched: number }> {
+  const reviewsInWindow: PullRequestReviewNode[] = [];
+  let pagesFetched = 0;
+  let cursor: string | null = null;
+  let hasNext = true;
+
+  while (hasNext) {
+    const page: UserPRReviewsResponse = cursor
+      ? await client.call<UserPRReviewsResponse>(USER_PR_REVIEWS_PAGE_QUERY, {
+          login,
+          since,
+          after: cursor,
+        })
+      : await client.call<UserPRReviewsResponse>(USER_PR_REVIEWS_QUERY, {
+          login,
+          since,
+        });
+    pagesFetched++;
+    if (!page.user) break;
+    const conn =
+      page.user.contributionsCollection.pullRequestReviewContributions;
+    const nextCursor = conn.pageInfo.endCursor;
+    if (cursor !== null && nextCursor === cursor) break;
+    for (const n of conn.nodes) {
+      if (n.pullRequestReview) reviewsInWindow.push(n.pullRequestReview);
+    }
+    hasNext = conn.pageInfo.hasNextPage;
+    cursor = nextCursor;
+  }
+
+  return { reviewsInWindow, pagesFetched };
+}

--- a/src/ingest/persistence.ts
+++ b/src/ingest/persistence.ts
@@ -1,13 +1,15 @@
-import type { DataSource, EntityManager } from 'typeorm';
+import type { EntityManager } from 'typeorm';
 import { AppUserProfileEntity } from '../database/entities/app/user-profile.entity.js';
 import { AppRepositoryEntity } from '../database/entities/app/repository.entity.js';
 import { AppUserActivityEntity } from '../database/entities/app/user-activity.entity.js';
 import { AppUserSyncEntity } from '../database/entities/app/user-sync.entity.js';
+import { AppUserDailyContributionEntity } from '../database/entities/app/user-daily-contribution.entity.js';
 import type { UserNode } from './graphql-types.js';
 import type { RepoAggregate } from './aggregate.js';
 
 const REPO_BATCH_SIZE = 500;
 const ACTIVITY_BATCH_SIZE = 1000;
+const CALENDAR_BATCH_SIZE = 1000;
 
 export async function upsertUserProfile(
   tx: EntityManager,
@@ -118,6 +120,7 @@ export async function replaceUserActivity(
     ['commits', 'commit'],
     ['pullRequests', 'pr'],
     ['issues', 'issue'],
+    ['prReviews', 'pr_review'],
     ['issueComments', 'issue_comment'],
     ['prComments', 'pr_comment'],
   ];
@@ -184,21 +187,31 @@ export async function markUserReady(
     .execute();
 }
 
-export async function markUserFailed(
-  ds: DataSource,
-  login: string,
-  error: string,
+export async function replaceUserDailyContributions(
+  tx: EntityManager,
+  user: UserNode,
+  dailyCounts: Map<string, number>,
 ): Promise<void> {
-  await ds
-    .createQueryBuilder()
-    .insert()
-    .into(AppUserSyncEntity)
-    .values({
-      login,
-      status: 'failed',
-      lastError: error,
-      updatedAt: () => 'NOW()',
-    })
-    .orUpdate(['status', 'last_error', 'updated_at'], ['login'])
-    .execute();
+  const userId = String(user.databaseId ?? 0);
+
+  await tx.delete(AppUserDailyContributionEntity, { userId });
+  if (dailyCounts.size === 0) return;
+
+  const rows = [...dailyCounts.entries()].map(([date, count]) => ({
+    userId,
+    day: new Date(date),
+    count,
+  }));
+
+  for (let i = 0; i < rows.length; i += CALENDAR_BATCH_SIZE) {
+    const chunk = rows.slice(i, i + CALENDAR_BATCH_SIZE);
+    await tx
+      .createQueryBuilder()
+      .insert()
+      .into(AppUserDailyContributionEntity)
+      .values(chunk)
+      .orUpdate(['count'], ['user_id', 'day'])
+      .execute();
+  }
 }
+

--- a/src/ingest/persistence.ts
+++ b/src/ingest/persistence.ts
@@ -1,0 +1,204 @@
+import type { DataSource, EntityManager } from 'typeorm';
+import { AppUserProfileEntity } from '../database/entities/app/user-profile.entity.js';
+import { AppRepositoryEntity } from '../database/entities/app/repository.entity.js';
+import { AppUserActivityEntity } from '../database/entities/app/user-activity.entity.js';
+import { AppUserSyncEntity } from '../database/entities/app/user-sync.entity.js';
+import type { UserNode } from './graphql-types.js';
+import type { RepoAggregate } from './aggregate.js';
+
+const REPO_BATCH_SIZE = 500;
+const ACTIVITY_BATCH_SIZE = 1000;
+
+export async function upsertUserProfile(
+  tx: EntityManager,
+  user: UserNode,
+): Promise<void> {
+  await tx
+    .createQueryBuilder()
+    .insert()
+    .into(AppUserProfileEntity)
+    .values({
+      userId: String(user.databaseId ?? 0),
+      login: user.login,
+      name: user.name,
+      avatarUrl: user.avatarUrl,
+      htmlUrl: user.url,
+      company: user.company,
+      location: user.location,
+      bio: user.bio,
+      blog: user.websiteUrl,
+      twitterUsername: user.twitterUsername,
+      publicRepos: user.repositories.totalCount,
+      followers: user.followers.totalCount,
+      following: user.following.totalCount,
+      type: 'User',
+      ghCreatedAt: new Date(user.createdAt),
+      fetchedAt: () => 'NOW()',
+    })
+    .orUpdate(
+      [
+        'login',
+        'name',
+        'avatar_url',
+        'html_url',
+        'company',
+        'location',
+        'bio',
+        'blog',
+        'twitter_username',
+        'public_repos',
+        'followers',
+        'following',
+        'fetched_at',
+      ],
+      ['user_id'],
+    )
+    .execute();
+}
+
+export async function upsertRepositories(
+  tx: EntityManager,
+  perRepo: Map<string, RepoAggregate>,
+): Promise<void> {
+  const rows = [...perRepo.values()].filter((r) => r.repoDatabaseId);
+  if (rows.length === 0) return;
+
+  for (let i = 0; i < rows.length; i += REPO_BATCH_SIZE) {
+    const chunk = rows.slice(i, i + REPO_BATCH_SIZE);
+    await tx
+      .createQueryBuilder()
+      .insert()
+      .into(AppRepositoryEntity)
+      .values(
+        chunk.map((r) => ({
+          repoId: String(r.repoDatabaseId),
+          repoName: r.nameWithOwner,
+          description: r.description,
+          htmlUrl: r.url,
+          forkCount: r.forkCount,
+          stargazerCount: r.stargazerCount,
+          primaryLanguage: r.primaryLanguage,
+          primaryLanguageColor: r.primaryLanguageColor,
+          licenseName: r.licenseName,
+          licenseSpdx: r.licenseSpdx,
+          topics: r.topics,
+        })),
+      )
+      .orUpdate(
+        [
+          'repo_name',
+          'description',
+          'html_url',
+          'fork_count',
+          'stargazer_count',
+          'primary_language',
+          'primary_language_color',
+          'license_name',
+          'license_spdx',
+          'topics',
+        ],
+        ['repo_id'],
+      )
+      .execute();
+  }
+}
+
+export async function replaceUserActivity(
+  tx: EntityManager,
+  user: UserNode,
+  perRepo: Map<string, RepoAggregate>,
+): Promise<void> {
+  const userId = String(user.databaseId ?? 0);
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  await tx.delete(AppUserActivityEntity, { userId });
+
+  const ACTIVITY_TYPES: Array<[keyof RepoAggregate, string]> = [
+    ['commits', 'commit'],
+    ['pullRequests', 'pr'],
+    ['issues', 'issue'],
+    ['issueComments', 'issue_comment'],
+    ['prComments', 'pr_comment'],
+  ];
+
+  const allRows: Array<{
+    userId: string;
+    day: Date;
+    repoId: string;
+    activityType: string;
+    activityCount: number;
+  }> = [];
+  for (const r of perRepo.values()) {
+    if (!r.repoDatabaseId) continue;
+    const repoId = String(r.repoDatabaseId);
+    for (const [field, activityType] of ACTIVITY_TYPES) {
+      const count = r[field] as number;
+      if (count <= 0) continue;
+      allRows.push({
+        userId,
+        day: today,
+        repoId,
+        activityType,
+        activityCount: count,
+      });
+    }
+  }
+  if (allRows.length === 0) return;
+
+  for (let i = 0; i < allRows.length; i += ACTIVITY_BATCH_SIZE) {
+    const chunk = allRows.slice(i, i + ACTIVITY_BATCH_SIZE);
+    await tx
+      .createQueryBuilder()
+      .insert()
+      .into(AppUserActivityEntity)
+      .values(chunk)
+      .orUpdate(
+        ['activity_count'],
+        ['user_id', 'day', 'repo_id', 'activity_type'],
+      )
+      .execute();
+  }
+}
+
+export async function markUserReady(
+  tx: EntityManager,
+  user: UserNode,
+): Promise<void> {
+  await tx
+    .createQueryBuilder()
+    .insert()
+    .into(AppUserSyncEntity)
+    .values({
+      login: user.login,
+      userId: String(user.databaseId ?? 0),
+      status: 'ready',
+      lastSyncedAt: () => 'NOW()',
+      lastError: null,
+      updatedAt: () => 'NOW()',
+    })
+    .orUpdate(
+      ['user_id', 'status', 'last_synced_at', 'last_error', 'updated_at'],
+      ['login'],
+    )
+    .execute();
+}
+
+export async function markUserFailed(
+  ds: DataSource,
+  login: string,
+  error: string,
+): Promise<void> {
+  await ds
+    .createQueryBuilder()
+    .insert()
+    .into(AppUserSyncEntity)
+    .values({
+      login,
+      status: 'failed',
+      lastError: error,
+      updatedAt: () => 'NOW()',
+    })
+    .orUpdate(['status', 'last_error', 'updated_at'], ['login'])
+    .execute();
+}

--- a/src/pipeline-v2/pipeline-v2.controller.ts
+++ b/src/pipeline-v2/pipeline-v2.controller.ts
@@ -1,7 +1,6 @@
-import { Controller, Post, Body, Get } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBody, ApiSecurity } from '@nestjs/swagger';
+import { Controller, Post, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiSecurity } from '@nestjs/swagger';
 import { PipelineV2Service } from './pipeline-v2.service.js';
-import { IngestUsersDto } from '../raw/dto/ingest-users.dto.js';
 
 @ApiTags('pipeline-v2')
 @ApiSecurity('X-API-Key')
@@ -9,28 +8,19 @@ import { IngestUsersDto } from '../raw/dto/ingest-users.dto.js';
 export class PipelineV2Controller {
   constructor(private readonly pipeline: PipelineV2Service) {}
 
-  @Post('analytics/report')
+  @Get('analytics/report')
   @ApiOperation({
     summary:
-      'Generate frontend analytics report (last 180 days, fork_count >= 3)',
+      'Generate frontend analytics report (last 180 days, fork_count >= 3) for all users in the DB.',
   })
-  @ApiBody({ type: IngestUsersDto })
-  getAnalyticsReport(@Body() body: IngestUsersDto) {
-    return this.pipeline.generateReport(body.users);
+  getAnalyticsReport() {
+    return this.pipeline.generateReport();
   }
 
-  @Post('removeUsers')
-  @ApiOperation({ summary: 'Remove users and their activity data' })
-  @ApiBody({ type: IngestUsersDto })
-  removeUsers(@Body() body: IngestUsersDto) {
-    return this.pipeline.removeUsers(body.users);
-  }
-
-  @Post('addNewUsers')
-  @ApiOperation({ summary: 'Add new users via GraphQL ingest' })
-  @ApiBody({ type: IngestUsersDto })
-  addNewUsers(@Body() body: IngestUsersDto) {
-    return this.pipeline.addNewUsers(body.users);
+  @Post('refreshAll')
+  @ApiOperation({ summary: 'Wipe all data and re-ingest from users.json (daily refresh)' })
+  refreshAll() {
+    return this.pipeline.refreshAll();
   }
 
   @Get('listUsers')

--- a/src/pipeline-v2/pipeline-v2.controller.ts
+++ b/src/pipeline-v2/pipeline-v2.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Post, Body, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBody, ApiSecurity } from '@nestjs/swagger';
+import { PipelineV2Service } from './pipeline-v2.service.js';
+import { IngestUsersDto } from '../raw/dto/ingest-users.dto.js';
+
+@ApiTags('pipeline-v2')
+@ApiSecurity('X-API-Key')
+@Controller('pipeline/v2')
+export class PipelineV2Controller {
+  constructor(private readonly pipeline: PipelineV2Service) {}
+
+  @Post('analytics/report')
+  @ApiOperation({
+    summary:
+      'Generate frontend analytics report (last 180 days, fork_count >= 3)',
+  })
+  @ApiBody({ type: IngestUsersDto })
+  getAnalyticsReport(@Body() body: IngestUsersDto) {
+    return this.pipeline.generateReport(body.users);
+  }
+
+  @Post('removeUsers')
+  @ApiOperation({ summary: 'Remove users and their activity data' })
+  @ApiBody({ type: IngestUsersDto })
+  removeUsers(@Body() body: IngestUsersDto) {
+    return this.pipeline.removeUsers(body.users);
+  }
+
+  @Post('addNewUsers')
+  @ApiOperation({ summary: 'Add new users via GraphQL ingest' })
+  @ApiBody({ type: IngestUsersDto })
+  addNewUsers(@Body() body: IngestUsersDto) {
+    return this.pipeline.addNewUsers(body.users);
+  }
+
+  @Get('listUsers')
+  @ApiOperation({ summary: 'List users grouped by sync status' })
+  listUsers() {
+    return this.pipeline.listUsers();
+  }
+}

--- a/src/pipeline-v2/pipeline-v2.module.ts
+++ b/src/pipeline-v2/pipeline-v2.module.ts
@@ -7,6 +7,7 @@ import { AppUserProfileEntity } from '../database/entities/app/user-profile.enti
 import { AppRepositoryEntity } from '../database/entities/app/repository.entity.js';
 import { AppUserActivityEntity } from '../database/entities/app/user-activity.entity.js';
 import { AppUserSyncEntity } from '../database/entities/app/user-sync.entity.js';
+import { AppUserDailyContributionEntity } from '../database/entities/app/user-daily-contribution.entity.js';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { AppUserSyncEntity } from '../database/entities/app/user-sync.entity.js'
       AppRepositoryEntity,
       AppUserActivityEntity,
       AppUserSyncEntity,
+      AppUserDailyContributionEntity,
     ]),
   ],
   controllers: [PipelineV2Controller],

--- a/src/pipeline-v2/pipeline-v2.module.ts
+++ b/src/pipeline-v2/pipeline-v2.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { IngestModule } from '../ingest/ingest.module.js';
+import { PipelineV2Service } from './pipeline-v2.service.js';
+import { PipelineV2Controller } from './pipeline-v2.controller.js';
+import { AppUserProfileEntity } from '../database/entities/app/user-profile.entity.js';
+import { AppRepositoryEntity } from '../database/entities/app/repository.entity.js';
+import { AppUserActivityEntity } from '../database/entities/app/user-activity.entity.js';
+import { AppUserSyncEntity } from '../database/entities/app/user-sync.entity.js';
+
+@Module({
+  imports: [
+    IngestModule,
+    TypeOrmModule.forFeature([
+      AppUserProfileEntity,
+      AppRepositoryEntity,
+      AppUserActivityEntity,
+      AppUserSyncEntity,
+    ]),
+  ],
+  controllers: [PipelineV2Controller],
+  providers: [PipelineV2Service],
+})
+export class PipelineV2Module {}

--- a/src/pipeline-v2/pipeline-v2.service.ts
+++ b/src/pipeline-v2/pipeline-v2.service.ts
@@ -1,16 +1,28 @@
-import { Injectable, BadRequestException, Logger } from '@nestjs/common';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { In, MoreThanOrEqual, Repository } from 'typeorm';
 import { GraphqlIngestService } from '../ingest/graphql-ingest.service.js';
+import {
+  upsertUserProfile,
+  upsertRepositories,
+  replaceUserActivity,
+  replaceUserDailyContributions,
+  markUserReady,
+} from '../ingest/persistence.js';
+import { MIN_FORK_COUNT } from '../ingest/constants.js';
 import { AppUserProfileEntity } from '../database/entities/app/user-profile.entity.js';
 import { AppRepositoryEntity } from '../database/entities/app/repository.entity.js';
 import { AppUserActivityEntity } from '../database/entities/app/user-activity.entity.js';
 import { AppUserSyncEntity } from '../database/entities/app/user-sync.entity.js';
+import { AppUserDailyContributionEntity } from '../database/entities/app/user-daily-contribution.entity.js';
 
 interface RepoActivityCounts {
   commits: number;
   pullRequests: number;
   issues: number;
+  prReviews: number;
   prComments: number;
   issueComments: number;
 }
@@ -31,6 +43,7 @@ interface UserSummaryTotals {
   totalCommits: number;
   totalPRs: number;
   totalIssues: number;
+  totalPRReviews: number;
   totalPRComments: number;
   totalIssueComments: number;
 }
@@ -41,11 +54,11 @@ interface AggregatedActivityRow {
   commits: number;
   prs: number;
   issues: number;
+  pr_reviews: number;
   pr_comments: number;
   issue_comments: number;
 }
 
-const MIN_FORK_COUNT = 3;
 const WINDOW_DAYS = 180;
 
 @Injectable()
@@ -61,101 +74,61 @@ export class PipelineV2Service {
     private readonly activityRepo: Repository<AppUserActivityEntity>,
     @InjectRepository(AppUserSyncEntity)
     private readonly syncRepo: Repository<AppUserSyncEntity>,
+    @InjectRepository(AppUserDailyContributionEntity)
+    private readonly dailyRepo: Repository<AppUserDailyContributionEntity>,
     private readonly ingest: GraphqlIngestService,
   ) {}
 
-  async addNewUsers(users: string[]) {
-    this.assertNonEmpty(users);
+  async refreshAll() {
+    const usersJson = await readFile(join(process.cwd(), 'users.json'), 'utf-8');
+    const users: string[] = JSON.parse(usersJson);
+    this.logger.log(`Refreshing ${users.length} users from users.json`);
 
-    const existingRows = await this.syncRepo.find({
-      where: { login: In(users) },
-      select: ['login'],
-    });
-    const existingLogins = new Set(existingRows.map((r) => r.login));
+    // Phase 1: fetch all from GitHub concurrently (no DB writes yet)
+    const fetched = await Promise.all(
+      users.map((login) => this.ingest.fetchUser(login)),
+    );
 
-    const newUsers: string[] = [];
-    const existingUsers: string[] = [];
-    for (const u of users) {
-      if (existingLogins.has(u)) existingUsers.push(u);
-      else newUsers.push(u);
-    }
+    const successful = fetched.filter((r) => r.status === 'ready');
+    const failed = fetched.filter((r) => r.status !== 'ready');
 
-    if (newUsers.length === 0) {
-      return {
-        message: 'All users already exist',
-        successfulUsers: [] as string[],
-        failedUsers: [] as string[],
-        existingUsers,
-      };
-    }
+    // Phase 2: single atomic transaction — wipe everything + write all results
+    await this.syncRepo.manager.transaction(async (tx) => {
+      await tx.clear(AppUserActivityEntity);
+      await tx.clear(AppUserDailyContributionEntity);
+      await tx.clear(AppUserProfileEntity);
+      await tx.clear(AppUserSyncEntity);
+      await tx.clear(AppRepositoryEntity);
 
-    await this.syncRepo
-      .createQueryBuilder()
-      .insert()
-      .values(
-        newUsers.map((login) => ({
-          login,
-          status: 'processing',
-          updatedAt: () => 'NOW()',
-        })),
-      )
-      .orUpdate(['status', 'updated_at'], ['login'])
-      .execute();
-
-    const results = await this.ingest.ingestUsers(newUsers);
-    const successfulUsers = results
-      .filter((r) => r.status === 'ready')
-      .map((r) => r.login);
-    const failedUsers = results
-      .filter((r) => r.status !== 'ready')
-      .map((r) => r.login);
-
-    return {
-      message: 'User processing completed',
-      successfulUsers,
-      failedUsers,
-      existingUsers,
-    };
-  }
-
-  async removeUsers(users: string[]) {
-    this.assertNonEmpty(users);
-    const removedUsers: string[] = [];
-    const failedUsers: string[] = [];
-
-    for (const login of users) {
-      try {
-        await this.syncRepo.manager.transaction(async (tx) => {
-          const sync = await tx.findOne(AppUserSyncEntity, {
-            where: { login },
-          });
-          const userId = sync?.userId ?? null;
-          if (userId) {
-            await tx.delete(AppUserActivityEntity, { userId });
-            await tx.delete(AppUserProfileEntity, { userId });
-          }
-          await tx.delete(AppUserSyncEntity, { login });
-        });
-        removedUsers.push(login);
-      } catch (e) {
-        this.logger.error(
-          `Failed to remove ${login}: ${e instanceof Error ? e.message : String(e)}`,
-        );
-        failedUsers.push(login);
+      for (const r of successful) {
+        if (r.status !== 'ready') continue;
+        await upsertUserProfile(tx, r.user);
+        await upsertRepositories(tx, r.perRepo);
+        await replaceUserActivity(tx, r.user, r.perRepo);
+        await replaceUserDailyContributions(tx, r.user, r.dailyCounts);
+        await markUserReady(tx, r.user);
       }
-    }
+
+      for (const r of failed) {
+        await tx
+          .createQueryBuilder()
+          .insert()
+          .into(AppUserSyncEntity)
+          .values({
+            login: r.login,
+            status: r.status,
+            lastError: r.error,
+            updatedAt: () => 'NOW()',
+          })
+          .orUpdate(['status', 'last_error', 'updated_at'], ['login'])
+          .execute();
+      }
+    });
 
     return {
-      message: 'User removal completed',
-      summary: {
-        requested: users.length,
-        removed: removedUsers.length,
-        failed: failedUsers.length,
-        skipped: 0,
-      },
-      removedUsers,
-      failedUsers,
-      skippedProcessing: [],
+      message: 'Refresh completed',
+      successfulUsers: successful.map((r) => r.login),
+      failedUsers: failed.map((r) => r.login),
     };
   }
 
@@ -185,17 +158,21 @@ export class PipelineV2Service {
     };
   }
 
-  async generateReport(usernames: string[]) {
-    this.assertNonEmpty(usernames);
-
+  async generateReport() {
     const since = new Date();
-    since.setDate(since.getDate() - WINDOW_DAYS);
+    since.setUTCHours(0, 0, 0, 0);
+    since.setUTCDate(since.getUTCDate() - WINDOW_DAYS);
     const sinceISO = since.toISOString();
     const todayISO = new Date().toISOString();
 
-    const users = await this.userRepo.find({
-      where: { login: In(usernames) },
-    });
+    const readyLogins = await this.syncRepo
+      .find({ where: { status: 'ready' }, select: ['login'] })
+      .then((rows) => rows.map((r) => r.login));
+
+    const users =
+      readyLogins.length > 0
+        ? await this.userRepo.find({ where: { login: In(readyLogins) } })
+        : [];
 
     const userIds = users.map((u) => u.userId);
 
@@ -227,6 +204,10 @@ export class PipelineV2Service {
               'issues',
             )
             .addSelect(
+              `COALESCE(SUM(CASE WHEN a.activity_type = 'pr_review' THEN a.activity_count ELSE 0 END), 0)::int`,
+              'pr_reviews',
+            )
+            .addSelect(
               `COALESCE(SUM(CASE WHEN a.activity_type = 'pr_comment' THEN a.activity_count ELSE 0 END), 0)::int`,
               'pr_comments',
             )
@@ -246,6 +227,26 @@ export class PipelineV2Service {
       const arr = activitiesByUser.get(a.user_id);
       if (arr) arr.push(a);
       else activitiesByUser.set(a.user_id, [a]);
+    }
+
+    const dailyRows =
+      userIds.length === 0
+        ? []
+        : await this.dailyRepo.find({
+            where: { userId: In(userIds), day: MoreThanOrEqual(since) },
+            order: { day: 'ASC' },
+          });
+    const dailyByUser = new Map<
+      string,
+      Array<{ date: string; count: number }>
+    >();
+    for (const d of dailyRows) {
+      const arr = dailyByUser.get(d.userId);
+      const dateStr =
+        typeof d.day === 'string' ? d.day : d.day.toISOString().slice(0, 10);
+      const entry = { date: dateStr, count: d.count };
+      if (arr) arr.push(entry);
+      else dailyByUser.set(d.userId, [entry]);
     }
 
     const usersOut = users.map((u) => {
@@ -271,6 +272,7 @@ export class PipelineV2Service {
         },
         repos: userRepos,
         summary: this.calculateUserSummary(userRepos),
+        dailyContributions: dailyByUser.get(u.userId) ?? [],
       };
     });
 
@@ -281,7 +283,177 @@ export class PipelineV2Service {
       todayISO,
     );
 
-    return { users: usersOut, globalSummary, excludedUsers: [] };
+    const contributorsByRepoId = new Map<
+      string,
+      Array<{ login: string; avatarUrl: string | null }>
+    >();
+    const userInfoById = new Map(
+      users.map((u) => [u.userId, { login: u.login, avatarUrl: u.avatarUrl }]),
+    );
+    for (const a of activities) {
+      const info = userInfoById.get(a.user_id);
+      if (!info) continue;
+      let arr = contributorsByRepoId.get(a.repo_id);
+      if (!arr) {
+        arr = [];
+        contributorsByRepoId.set(a.repo_id, arr);
+      }
+      if (!arr.some((c) => c.login === info.login)) {
+        arr.push(info);
+      }
+    }
+
+    const repoLeaderboard = await this.buildRepoLeaderboard(
+      userIds,
+      sinceISO,
+      contributorsByRepoId,
+    );
+
+    const dailyTotals = this.buildCommunityTimeline(dailyRows);
+
+    return {
+      users: usersOut,
+      globalSummary,
+      repoLeaderboard,
+      dailyTotals,
+      excludedUsers: [],
+    };
+  }
+
+  private buildCommunityTimeline(
+    dailyRows: AppUserDailyContributionEntity[],
+  ): Array<{ date: string; count: number }> {
+    const byDay = new Map<string, number>();
+    for (const d of dailyRows) {
+      const date =
+        typeof d.day === 'string' ? d.day : d.day.toISOString().slice(0, 10);
+      byDay.set(date, (byDay.get(date) || 0) + d.count);
+    }
+    return [...byDay.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([date, count]) => ({ date, count }));
+  }
+
+  private async buildRepoLeaderboard(
+    userIds: string[],
+    sinceISO: string,
+    contributorsByRepoId: Map<
+      string,
+      Array<{ login: string; avatarUrl: string | null }>
+    >,
+  ) {
+    if (userIds.length === 0) return [];
+
+    interface RepoLeaderboardRow {
+      repo_id: string;
+      repo_name: string;
+      description: string | null;
+      html_url: string | null;
+      fork_count: number;
+      stargazer_count: number | null;
+      primary_language: string | null;
+      primary_language_color: string | null;
+      license_name: string | null;
+      license_spdx: string | null;
+      topics: string[] | null;
+      commits: number;
+      prs: number;
+      issues: number;
+      pr_reviews: number;
+      pr_comments: number;
+      issue_comments: number;
+      contributors: number;
+    }
+
+    const rows: RepoLeaderboardRow[] = await this.activityRepo
+      .createQueryBuilder('a')
+      .innerJoin(
+        AppRepositoryEntity,
+        'r',
+        'r.repo_id = a.repo_id AND r.fork_count >= :minForks',
+        { minForks: MIN_FORK_COUNT },
+      )
+      .select('r.repo_id', 'repo_id')
+      .addSelect('r.repo_name', 'repo_name')
+      .addSelect('r.description', 'description')
+      .addSelect('r.html_url', 'html_url')
+      .addSelect('r.fork_count', 'fork_count')
+      .addSelect('r.stargazer_count', 'stargazer_count')
+      .addSelect('r.primary_language', 'primary_language')
+      .addSelect('r.primary_language_color', 'primary_language_color')
+      .addSelect('r.license_name', 'license_name')
+      .addSelect('r.license_spdx', 'license_spdx')
+      .addSelect('r.topics', 'topics')
+      .addSelect(
+        `COALESCE(SUM(CASE WHEN a.activity_type = 'commit' THEN a.activity_count ELSE 0 END), 0)::int`,
+        'commits',
+      )
+      .addSelect(
+        `COALESCE(SUM(CASE WHEN a.activity_type = 'pr' THEN a.activity_count ELSE 0 END), 0)::int`,
+        'prs',
+      )
+      .addSelect(
+        `COALESCE(SUM(CASE WHEN a.activity_type = 'issue' THEN a.activity_count ELSE 0 END), 0)::int`,
+        'issues',
+      )
+      .addSelect(
+        `COALESCE(SUM(CASE WHEN a.activity_type = 'pr_review' THEN a.activity_count ELSE 0 END), 0)::int`,
+        'pr_reviews',
+      )
+      .addSelect(
+        `COALESCE(SUM(CASE WHEN a.activity_type = 'pr_comment' THEN a.activity_count ELSE 0 END), 0)::int`,
+        'pr_comments',
+      )
+      .addSelect(
+        `COALESCE(SUM(CASE WHEN a.activity_type = 'issue_comment' THEN a.activity_count ELSE 0 END), 0)::int`,
+        'issue_comments',
+      )
+      .addSelect('COUNT(DISTINCT a.user_id)::int', 'contributors')
+      .where('a.day >= :since', { since: sinceISO })
+      .andWhere('a.user_id IN (:...userIds)', { userIds })
+      .groupBy('r.repo_id')
+      .addGroupBy('r.repo_name')
+      .addGroupBy('r.description')
+      .addGroupBy('r.html_url')
+      .addGroupBy('r.fork_count')
+      .addGroupBy('r.stargazer_count')
+      .addGroupBy('r.primary_language')
+      .addGroupBy('r.primary_language_color')
+      .addGroupBy('r.license_name')
+      .addGroupBy('r.license_spdx')
+      .addGroupBy('r.topics')
+      .getRawMany<RepoLeaderboardRow>();
+
+    return rows
+      .map((r) => ({
+        repoName: r.repo_name,
+        description: r.description,
+        url: r.html_url,
+        forkCount: r.fork_count,
+        stargazerCount: r.stargazer_count ?? 0,
+        primaryLanguage: r.primary_language,
+        primaryLanguageColor: r.primary_language_color,
+        licenseName: r.license_name,
+        licenseSpdx: r.license_spdx,
+        topics: r.topics ?? [],
+        commits: r.commits,
+        pullRequests: r.prs,
+        issues: r.issues,
+        prReviews: r.pr_reviews,
+        prComments: r.pr_comments,
+        issueComments: r.issue_comments,
+        contributors: r.contributors,
+        contributorList: contributorsByRepoId.get(r.repo_id) ?? [],
+        totalActivity:
+          r.commits +
+          r.prs +
+          r.issues +
+          r.pr_reviews +
+          r.pr_comments +
+          r.issue_comments,
+      }))
+      .filter((r) => r.totalActivity > 0)
+      .sort((a, b) => b.totalActivity - a.totalActivity);
   }
 
   private buildUserRepos(
@@ -289,24 +461,25 @@ export class PipelineV2Service {
     repoById: Map<string, AppRepositoryEntity>,
   ): UserRepoSummary[] {
     const out: UserRepoSummary[] = [];
-    for (const a of userActivities) {
-      const r = repoById.get(a.repo_id);
-      if (!r) continue;
+    for (const activity of userActivities) {
+      const repo = repoById.get(activity.repo_id);
+      if (!repo) continue;
       out.push({
-        repoName: r.repoName,
-        description: r.description,
-        url: r.htmlUrl,
-        primaryLanguage: r.primaryLanguage,
-        primaryLanguageColor: r.primaryLanguageColor,
-        stargazerCount: r.stargazerCount,
-        licenseName: r.licenseName,
-        licenseSpdx: r.licenseSpdx,
-        topics: r.topics ?? [],
-        commits: a.commits,
-        pullRequests: a.prs,
-        issues: a.issues,
-        prComments: a.pr_comments,
-        issueComments: a.issue_comments,
+        repoName: repo.repoName,
+        description: repo.description,
+        url: repo.htmlUrl,
+        primaryLanguage: repo.primaryLanguage,
+        primaryLanguageColor: repo.primaryLanguageColor,
+        stargazerCount: repo.stargazerCount,
+        licenseName: repo.licenseName,
+        licenseSpdx: repo.licenseSpdx,
+        topics: repo.topics ?? [],
+        commits: activity.commits,
+        pullRequests: activity.prs,
+        issues: activity.issues,
+        prReviews: activity.pr_reviews,
+        prComments: activity.pr_comments,
+        issueComments: activity.issue_comments,
       });
     }
     return out;
@@ -314,17 +487,19 @@ export class PipelineV2Service {
 
   private calculateUserSummary(repos: UserRepoSummary[]): UserSummaryTotals {
     return repos.reduce<UserSummaryTotals>(
-      (s, r) => ({
-        totalCommits: s.totalCommits + r.commits,
-        totalPRs: s.totalPRs + r.pullRequests,
-        totalIssues: s.totalIssues + r.issues,
-        totalPRComments: s.totalPRComments + r.prComments,
-        totalIssueComments: s.totalIssueComments + r.issueComments,
+      (totals, repo) => ({
+        totalCommits: totals.totalCommits + repo.commits,
+        totalPRs: totals.totalPRs + repo.pullRequests,
+        totalIssues: totals.totalIssues + repo.issues,
+        totalPRReviews: totals.totalPRReviews + repo.prReviews,
+        totalPRComments: totals.totalPRComments + repo.prComments,
+        totalIssueComments: totals.totalIssueComments + repo.issueComments,
       }),
       {
         totalCommits: 0,
         totalPRs: 0,
         totalIssues: 0,
+        totalPRReviews: 0,
         totalPRComments: 0,
         totalIssueComments: 0,
       },
@@ -338,17 +513,19 @@ export class PipelineV2Service {
     todayISO: string,
   ) {
     const totals = activities.reduce(
-      (s, a) => ({
-        totalCommits: s.totalCommits + a.commits,
-        totalPRs: s.totalPRs + a.prs,
-        totalIssues: s.totalIssues + a.issues,
-        totalPRComments: s.totalPRComments + a.pr_comments,
-        totalIssueComments: s.totalIssueComments + a.issue_comments,
+      (acc, activity) => ({
+        totalCommits: acc.totalCommits + activity.commits,
+        totalPRs: acc.totalPRs + activity.prs,
+        totalIssues: acc.totalIssues + activity.issues,
+        totalPRReviews: acc.totalPRReviews + activity.pr_reviews,
+        totalPRComments: acc.totalPRComments + activity.pr_comments,
+        totalIssueComments: acc.totalIssueComments + activity.issue_comments,
       }),
       {
         totalCommits: 0,
         totalPRs: 0,
         totalIssues: 0,
+        totalPRReviews: 0,
         totalPRComments: 0,
         totalIssueComments: 0,
       },
@@ -367,9 +544,4 @@ export class PipelineV2Service {
     };
   }
 
-  private assertNonEmpty(users: string[]): void {
-    if (!Array.isArray(users) || users.length === 0) {
-      throw new BadRequestException('users must be a non-empty array');
-    }
-  }
 }

--- a/src/pipeline-v2/pipeline-v2.service.ts
+++ b/src/pipeline-v2/pipeline-v2.service.ts
@@ -1,0 +1,375 @@
+import { Injectable, BadRequestException, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { GraphqlIngestService } from '../ingest/graphql-ingest.service.js';
+import { AppUserProfileEntity } from '../database/entities/app/user-profile.entity.js';
+import { AppRepositoryEntity } from '../database/entities/app/repository.entity.js';
+import { AppUserActivityEntity } from '../database/entities/app/user-activity.entity.js';
+import { AppUserSyncEntity } from '../database/entities/app/user-sync.entity.js';
+
+interface RepoActivityCounts {
+  commits: number;
+  pullRequests: number;
+  issues: number;
+  prComments: number;
+  issueComments: number;
+}
+
+interface UserRepoSummary extends RepoActivityCounts {
+  repoName: string | null;
+  description: string | null;
+  url: string | null;
+  primaryLanguage: string | null;
+  primaryLanguageColor: string | null;
+  stargazerCount: number;
+  licenseName: string | null;
+  licenseSpdx: string | null;
+  topics: string[];
+}
+
+interface UserSummaryTotals {
+  totalCommits: number;
+  totalPRs: number;
+  totalIssues: number;
+  totalPRComments: number;
+  totalIssueComments: number;
+}
+
+interface AggregatedActivityRow {
+  user_id: string;
+  repo_id: string;
+  commits: number;
+  prs: number;
+  issues: number;
+  pr_comments: number;
+  issue_comments: number;
+}
+
+const MIN_FORK_COUNT = 3;
+const WINDOW_DAYS = 180;
+
+@Injectable()
+export class PipelineV2Service {
+  private readonly logger = new Logger(PipelineV2Service.name);
+
+  constructor(
+    @InjectRepository(AppUserProfileEntity)
+    private readonly userRepo: Repository<AppUserProfileEntity>,
+    @InjectRepository(AppRepositoryEntity)
+    private readonly repoRepo: Repository<AppRepositoryEntity>,
+    @InjectRepository(AppUserActivityEntity)
+    private readonly activityRepo: Repository<AppUserActivityEntity>,
+    @InjectRepository(AppUserSyncEntity)
+    private readonly syncRepo: Repository<AppUserSyncEntity>,
+    private readonly ingest: GraphqlIngestService,
+  ) {}
+
+  async addNewUsers(users: string[]) {
+    this.assertNonEmpty(users);
+
+    const existingRows = await this.syncRepo.find({
+      where: { login: In(users) },
+      select: ['login'],
+    });
+    const existingLogins = new Set(existingRows.map((r) => r.login));
+
+    const newUsers: string[] = [];
+    const existingUsers: string[] = [];
+    for (const u of users) {
+      if (existingLogins.has(u)) existingUsers.push(u);
+      else newUsers.push(u);
+    }
+
+    if (newUsers.length === 0) {
+      return {
+        message: 'All users already exist',
+        successfulUsers: [] as string[],
+        failedUsers: [] as string[],
+        existingUsers,
+      };
+    }
+
+    await this.syncRepo
+      .createQueryBuilder()
+      .insert()
+      .values(
+        newUsers.map((login) => ({
+          login,
+          status: 'processing',
+          updatedAt: () => 'NOW()',
+        })),
+      )
+      .orUpdate(['status', 'updated_at'], ['login'])
+      .execute();
+
+    const results = await this.ingest.ingestUsers(newUsers);
+    const successfulUsers = results
+      .filter((r) => r.status === 'ready')
+      .map((r) => r.login);
+    const failedUsers = results
+      .filter((r) => r.status !== 'ready')
+      .map((r) => r.login);
+
+    return {
+      message: 'User processing completed',
+      successfulUsers,
+      failedUsers,
+      existingUsers,
+    };
+  }
+
+  async removeUsers(users: string[]) {
+    this.assertNonEmpty(users);
+    const removedUsers: string[] = [];
+    const failedUsers: string[] = [];
+
+    for (const login of users) {
+      try {
+        await this.syncRepo.manager.transaction(async (tx) => {
+          const sync = await tx.findOne(AppUserSyncEntity, {
+            where: { login },
+          });
+          const userId = sync?.userId ?? null;
+          if (userId) {
+            await tx.delete(AppUserActivityEntity, { userId });
+            await tx.delete(AppUserProfileEntity, { userId });
+          }
+          await tx.delete(AppUserSyncEntity, { login });
+        });
+        removedUsers.push(login);
+      } catch (e) {
+        this.logger.error(
+          `Failed to remove ${login}: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        failedUsers.push(login);
+      }
+    }
+
+    return {
+      message: 'User removal completed',
+      summary: {
+        requested: users.length,
+        removed: removedUsers.length,
+        failed: failedUsers.length,
+        skipped: 0,
+      },
+      removedUsers,
+      failedUsers,
+      skippedProcessing: [],
+    };
+  }
+
+  async listUsers() {
+    const rows = await this.syncRepo.find({
+      select: ['login', 'status'],
+      order: { login: 'ASC' },
+    });
+
+    const ready = rows.filter((r) => r.status === 'ready').map((r) => r.login);
+    const processing = rows
+      .filter((r) => r.status === 'processing')
+      .map((r) => r.login);
+    const pending = rows
+      .filter((r) => r.status === 'pending')
+      .map((r) => r.login);
+    const failed = rows
+      .filter((r) => r.status === 'failed')
+      .map((r) => r.login);
+
+    return {
+      total: rows.length,
+      ready: { count: ready.length, users: ready },
+      processing: { count: processing.length, users: processing },
+      pending: { count: pending.length, users: pending },
+      failed: { count: failed.length, users: failed },
+    };
+  }
+
+  async generateReport(usernames: string[]) {
+    this.assertNonEmpty(usernames);
+
+    const since = new Date();
+    since.setDate(since.getDate() - WINDOW_DAYS);
+    const sinceISO = since.toISOString();
+    const todayISO = new Date().toISOString();
+
+    const users = await this.userRepo.find({
+      where: { login: In(usernames) },
+    });
+
+    const userIds = users.map((u) => u.userId);
+
+    const repos = await this.repoRepo
+      .createQueryBuilder('r')
+      .where('r.fork_count >= :minForks', { minForks: MIN_FORK_COUNT })
+      .getMany();
+
+    const repoIds = repos.map((r) => r.repoId);
+    const repoById = new Map(repos.map((r) => [r.repoId, r]));
+
+    const activities: AggregatedActivityRow[] =
+      userIds.length === 0 || repoIds.length === 0
+        ? []
+        : await this.activityRepo
+            .createQueryBuilder('a')
+            .select('a.user_id', 'user_id')
+            .addSelect('a.repo_id', 'repo_id')
+            .addSelect(
+              `COALESCE(SUM(CASE WHEN a.activity_type = 'commit' THEN a.activity_count ELSE 0 END), 0)::int`,
+              'commits',
+            )
+            .addSelect(
+              `COALESCE(SUM(CASE WHEN a.activity_type = 'pr' THEN a.activity_count ELSE 0 END), 0)::int`,
+              'prs',
+            )
+            .addSelect(
+              `COALESCE(SUM(CASE WHEN a.activity_type = 'issue' THEN a.activity_count ELSE 0 END), 0)::int`,
+              'issues',
+            )
+            .addSelect(
+              `COALESCE(SUM(CASE WHEN a.activity_type = 'pr_comment' THEN a.activity_count ELSE 0 END), 0)::int`,
+              'pr_comments',
+            )
+            .addSelect(
+              `COALESCE(SUM(CASE WHEN a.activity_type = 'issue_comment' THEN a.activity_count ELSE 0 END), 0)::int`,
+              'issue_comments',
+            )
+            .where('a.day >= :since', { since: sinceISO })
+            .andWhere('a.user_id IN (:...userIds)', { userIds })
+            .andWhere('a.repo_id IN (:...repoIds)', { repoIds })
+            .groupBy('a.user_id')
+            .addGroupBy('a.repo_id')
+            .getRawMany<AggregatedActivityRow>();
+
+    const activitiesByUser = new Map<string, AggregatedActivityRow[]>();
+    for (const a of activities) {
+      const arr = activitiesByUser.get(a.user_id);
+      if (arr) arr.push(a);
+      else activitiesByUser.set(a.user_id, [a]);
+    }
+
+    const usersOut = users.map((u) => {
+      const userRepos = this.buildUserRepos(
+        activitiesByUser.get(u.userId) ?? [],
+        repoById,
+      );
+      return {
+        user: {
+          username: u.login,
+          displayName: u.name,
+          avatarUrl: u.avatarUrl,
+          bio: u.bio,
+          location: u.location,
+          company: u.company,
+          blog: u.blog,
+          twitterUsername: u.twitterUsername,
+          publicRepos: u.publicRepos,
+          followers: u.followers,
+          following: u.following,
+          accountType: u.type,
+          createdAt: u.ghCreatedAt?.toISOString(),
+        },
+        repos: userRepos,
+        summary: this.calculateUserSummary(userRepos),
+      };
+    });
+
+    const globalSummary = this.buildGlobalSummary(
+      activities,
+      usersOut.length,
+      sinceISO,
+      todayISO,
+    );
+
+    return { users: usersOut, globalSummary, excludedUsers: [] };
+  }
+
+  private buildUserRepos(
+    userActivities: AggregatedActivityRow[],
+    repoById: Map<string, AppRepositoryEntity>,
+  ): UserRepoSummary[] {
+    const out: UserRepoSummary[] = [];
+    for (const a of userActivities) {
+      const r = repoById.get(a.repo_id);
+      if (!r) continue;
+      out.push({
+        repoName: r.repoName,
+        description: r.description,
+        url: r.htmlUrl,
+        primaryLanguage: r.primaryLanguage,
+        primaryLanguageColor: r.primaryLanguageColor,
+        stargazerCount: r.stargazerCount,
+        licenseName: r.licenseName,
+        licenseSpdx: r.licenseSpdx,
+        topics: r.topics ?? [],
+        commits: a.commits,
+        pullRequests: a.prs,
+        issues: a.issues,
+        prComments: a.pr_comments,
+        issueComments: a.issue_comments,
+      });
+    }
+    return out;
+  }
+
+  private calculateUserSummary(repos: UserRepoSummary[]): UserSummaryTotals {
+    return repos.reduce<UserSummaryTotals>(
+      (s, r) => ({
+        totalCommits: s.totalCommits + r.commits,
+        totalPRs: s.totalPRs + r.pullRequests,
+        totalIssues: s.totalIssues + r.issues,
+        totalPRComments: s.totalPRComments + r.prComments,
+        totalIssueComments: s.totalIssueComments + r.issueComments,
+      }),
+      {
+        totalCommits: 0,
+        totalPRs: 0,
+        totalIssues: 0,
+        totalPRComments: 0,
+        totalIssueComments: 0,
+      },
+    );
+  }
+
+  private buildGlobalSummary(
+    activities: AggregatedActivityRow[],
+    totalUsers: number,
+    sinceISO: string,
+    todayISO: string,
+  ) {
+    const totals = activities.reduce(
+      (s, a) => ({
+        totalCommits: s.totalCommits + a.commits,
+        totalPRs: s.totalPRs + a.prs,
+        totalIssues: s.totalIssues + a.issues,
+        totalPRComments: s.totalPRComments + a.pr_comments,
+        totalIssueComments: s.totalIssueComments + a.issue_comments,
+      }),
+      {
+        totalCommits: 0,
+        totalPRs: 0,
+        totalIssues: 0,
+        totalPRComments: 0,
+        totalIssueComments: 0,
+      },
+    );
+
+    const uniqueRepos = new Set(activities.map((a) => a.repo_id));
+
+    return {
+      ...totals,
+      totalRepos: uniqueRepos.size,
+      successfulUsers: totalUsers,
+      failedUsers: 0,
+      totalUsers,
+      analysisTimeframe: `${sinceISO.slice(0, 10)} to ${todayISO.slice(0, 10)}`,
+      minForkCountFilter: String(MIN_FORK_COUNT),
+    };
+  }
+
+  private assertNonEmpty(users: string[]): void {
+    if (!Array.isArray(users) || users.length === 0) {
+      throw new BadRequestException('users must be a non-empty array');
+    }
+  }
+}

--- a/users.json
+++ b/users.json
@@ -1,0 +1,19 @@
+[
+  "Lidor57",
+  "NoamGaash",
+  "UrielOfir",
+  "barlavi1",
+  "lirantal",
+  "fruch",
+  "davidmeirlevy",
+  "baruchiro",
+  "sivanbecker",
+  "Meir-Crombie",
+  "ShacharES",
+  "szabgab",
+  "zvielkoren",
+  "Tamir198",
+  "TzofiyaE",
+  "moti-gabay",
+  "inas-sirhan"
+]


### PR DESCRIPTION
- Replace REST GitHub API with GraphQL ingest (~20-30x faster: ~60s vs 20-30 min for 17 users)
- Add /pipeline/v2 endpoints: GET analytics/report, POST refreshAll, GET listUsers
- refreshAll reads users.json, fetches all users concurrently, writes atomically in one transaction (wipe + write all)
- generateReport returns only ready users, eliminating race conditions on partial data
- Add OSS-filtered daily contributions (fork count >= 3) for per-user activity timeline
- Add repo leaderboard with commit/PR/issue/comment counts and repo metadata
- Add community daily totals aggregation
- Fix GraphQL variable naming bug that broke overflow commit/flat queries
- Simplify GitHub Action: POST /pipeline/v2/refreshAll, no body, no max-time
- Add users.json as source of truth for dashboard members