### PR TITLE
fix(ingest): prevent unhandled rejection from dangling reviewsP

### DIFF
--- a/src/ingest/graphql-ingest.service.ts
+++ b/src/ingest/graphql-ingest.service.ts
@@ -78,6 +78,10 @@ export class GraphqlIngestService {
 
       const mainP = this.client.call<UserActivityResponse>(USER_ACTIVITY_QUERY, { login, since });
       const reviewsP = fetchPRReviewsInWindow(this.client, login, since);
+      // Mark reviewsP as handled so an early return/throw in this function
+      // doesn't leave it dangling and crash the process via unhandled rejection.
+      // The real handler is the await inside Promise.all below.
+      reviewsP.catch(() => {});
 
       const primary = await mainP;
       if (!primary.user) {


### PR DESCRIPTION
When fetchUser returns early (user not found) or throws (e.g. GitHub 401), the parallel reviewsP promise is left dangling. If it later rejects, Node treats it as an unhandled rejection and crashes the process. Attach a no-op catch handler to mark it as handled — the real await/error handling still happens at the Promise.all below.