### PR TITLE
feat(pipeline-v2): rolling 6-month activity window per user

### DIFF
--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -15,6 +15,7 @@ import { AddMissingFields1755620000000 } from './migrations/1755620000000-AddMis
 import { AddOwnerUserIdToRepository1755625000000 } from './migrations/1755625000000-AddOwnerUserIdToRepository.js';
 import { AddLastSyncedAtToUsers1755630000000 } from './migrations/1755630000000-AddLastSyncedAtToUsers.js';
 import { CreateGraphqlPipelineTables1755900000000 } from './migrations/1755900000000-CreateGraphqlPipelineTables.js';
+import { AddUserRollingActivity1756000000000 } from './migrations/1756000000000-AddUserRollingActivity.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -48,6 +49,7 @@ const dataSource = new DataSource({
     AddOwnerUserIdToRepository1755625000000,
     AddLastSyncedAtToUsers1755630000000,
     CreateGraphqlPipelineTables1755900000000,
+    AddUserRollingActivity1756000000000,
   ],
   migrationsTableName: 'typeorm_migrations',
   schema: 'public',

--- a/src/database/entities/app/user-rolling-activity.entity.ts
+++ b/src/database/entities/app/user-rolling-activity.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'user_rolling_activity' })
+export class AppUserRollingActivityEntity {
+  @PrimaryColumn('varchar', { length: 64, name: 'user_id' })
+  userId!: string;
+
+  @PrimaryColumn('date')
+  day!: Date;
+
+  @Column('integer', { default: 0 })
+  total!: number;
+}

--- a/src/database/migrations/1756000000000-AddUserRollingActivity.ts
+++ b/src/database/migrations/1756000000000-AddUserRollingActivity.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserRollingActivity1756000000000 implements MigrationInterface {
+  name = 'AddUserRollingActivity1756000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS user_rolling_activity (
+        user_id  VARCHAR(64) NOT NULL,
+        day      DATE        NOT NULL,
+        total    INTEGER     DEFAULT 0,
+        PRIMARY KEY (user_id, day)
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS idx_user_rolling_activity_day ON user_rolling_activity (day)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS user_rolling_activity`);
+  }
+}

--- a/src/ingest/__tests__/rolling-activity.spec.ts
+++ b/src/ingest/__tests__/rolling-activity.spec.ts
@@ -1,0 +1,66 @@
+import { computeRollingActivity } from '../persistence.js';
+
+describe('computeRollingActivity', () => {
+  function dateNDaysAgo(n: number): string {
+    const d = new Date();
+    d.setUTCHours(0, 0, 0, 0);
+    d.setUTCDate(d.getUTCDate() - n);
+    return d.toISOString().slice(0, 10);
+  }
+
+  it('returns rolling sums covering the last `windowDays` days', () => {
+    const daily = new Map<string, number>();
+    daily.set(dateNDaysAgo(0), 1);
+    daily.set(dateNDaysAgo(1), 2);
+    daily.set(dateNDaysAgo(2), 3);
+
+    const result = computeRollingActivity(daily, 3);
+
+    // We expect points for the last 3 days (today, today-1, today-2).
+    expect(result.size).toBe(3);
+    // today = sum of last 3 days = 1+2+3 = 6
+    expect(result.get(dateNDaysAgo(0))).toBe(6);
+    // today-1 = sum of (today-1, today-2, today-3) = 2+3+0 = 5
+    expect(result.get(dateNDaysAgo(1))).toBe(5);
+    // today-2 = sum of (today-2, today-3, today-4) = 3+0+0 = 3
+    expect(result.get(dateNDaysAgo(2))).toBe(3);
+  });
+
+  it('treats missing days as zero', () => {
+    const daily = new Map<string, number>();
+    daily.set(dateNDaysAgo(0), 5);
+    // No other days populated.
+
+    const result = computeRollingActivity(daily, 3);
+    expect(result.get(dateNDaysAgo(0))).toBe(5);
+    expect(result.get(dateNDaysAgo(1))).toBe(0);
+    expect(result.get(dateNDaysAgo(2))).toBe(0);
+  });
+
+  it('returns empty map when no data', () => {
+    const result = computeRollingActivity(new Map(), 3);
+    // Even with no data, we still produce rolling points (all zeroes)
+    // for the last `windowDays` days.
+    expect(result.size).toBe(3);
+    for (const v of result.values()) expect(v).toBe(0);
+  });
+
+  it('produces 180 points for default window=180', () => {
+    const result = computeRollingActivity(new Map(), 180);
+    expect(result.size).toBe(180);
+  });
+
+  it('correctly sums a 6-month window with mixed activity', () => {
+    const daily = new Map<string, number>();
+    // 100 commits/week for 26 weeks (~182 days) ending today
+    for (let i = 0; i < 182; i++) {
+      daily.set(dateNDaysAgo(i), 100 / 7);
+    }
+
+    const result = computeRollingActivity(daily, 180);
+    const today = result.get(dateNDaysAgo(0))!;
+    // ~180 days × (100/7) ≈ 2571
+    expect(today).toBeGreaterThan(2500);
+    expect(today).toBeLessThan(2700);
+  });
+});

--- a/src/ingest/graphql-ingest.service.ts
+++ b/src/ingest/graphql-ingest.service.ts
@@ -70,7 +70,11 @@ export class GraphqlIngestService {
     windowDays = DEFAULT_WINDOW_DAYS,
   ): Promise<FetchedUser> {
     const start = Date.now();
-    const sinceMs = Date.now() - windowDays * 86_400_000;
+    // Anchor the window to today's midnight UTC so boundaries don't slide
+    // with the wall-clock time the refresh happens to run.
+    const todayMidnight = new Date();
+    todayMidnight.setUTCHours(0, 0, 0, 0);
+    const sinceMs = todayMidnight.getTime() - windowDays * 86_400_000;
     const since = new Date(sinceMs).toISOString();
 
     try {

--- a/src/ingest/persistence.ts
+++ b/src/ingest/persistence.ts
@@ -4,12 +4,18 @@ import { AppRepositoryEntity } from '../database/entities/app/repository.entity.
 import { AppUserActivityEntity } from '../database/entities/app/user-activity.entity.js';
 import { AppUserSyncEntity } from '../database/entities/app/user-sync.entity.js';
 import { AppUserDailyContributionEntity } from '../database/entities/app/user-daily-contribution.entity.js';
+import { AppUserRollingActivityEntity } from '../database/entities/app/user-rolling-activity.entity.js';
 import type { UserNode } from './graphql-types.js';
 import type { RepoAggregate } from './aggregate.js';
 
 const REPO_BATCH_SIZE = 500;
 const ACTIVITY_BATCH_SIZE = 1000;
 const CALENDAR_BATCH_SIZE = 1000;
+
+// FUTURE OPTIMIZATION: each replace*() function below issues one INSERT per
+// user. At 17 users this is fine, but at 1000+ users the per-user round-trips
+// dominate. Refactor refreshAll to collect all rows across users first, then
+// run a single bulk INSERT per table chunked by Postgres parameter limits.
 
 export async function upsertUserProfile(
   tx: EntityManager,
@@ -185,6 +191,75 @@ export async function markUserReady(
       ['login'],
     )
     .execute();
+}
+
+/**
+ * Compute rolling 180-day totals from 365 days of daily contribution data.
+ * For each day in the last 180 days, returns the sum of OSS contributions
+ * in the 180 days ending on that day. This produces a time-series showing
+ * how the user's "last 6 months activity" has trended over time.
+ */
+export function computeRollingActivity(
+  daily365: Map<string, number>,
+  windowDays = 180,
+): Map<string, number> {
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  // We want `windowDays` output points (today, today-1, ..., today-(windowDays-1)).
+  // The earliest output point's window starts at today-(2*windowDays-2) and ends
+  // at today-(windowDays-1). So we need (2*windowDays-1) days of input data.
+  const earliest = new Date(today);
+  earliest.setUTCDate(earliest.getUTCDate() - (2 * windowDays - 2));
+
+  const dailyArr: Array<{ date: string; count: number }> = [];
+  for (
+    let dt = new Date(earliest);
+    dt <= today;
+    dt.setUTCDate(dt.getUTCDate() + 1)
+  ) {
+    const dateStr = dt.toISOString().slice(0, 10);
+    dailyArr.push({ date: dateStr, count: daily365.get(dateStr) ?? 0 });
+  }
+
+  const result = new Map<string, number>();
+  let runningSum = 0;
+  for (let i = 0; i < dailyArr.length; i++) {
+    runningSum += dailyArr[i].count;
+    if (i >= windowDays) runningSum -= dailyArr[i - windowDays].count;
+    if (i >= windowDays - 1) {
+      result.set(dailyArr[i].date, runningSum);
+    }
+  }
+  return result;
+}
+
+export async function replaceUserRollingActivity(
+  tx: EntityManager,
+  user: UserNode,
+  rollingTotals: Map<string, number>,
+): Promise<void> {
+  const userId = String(user.databaseId ?? 0);
+
+  await tx.delete(AppUserRollingActivityEntity, { userId });
+  if (rollingTotals.size === 0) return;
+
+  const rows = [...rollingTotals.entries()].map(([date, total]) => ({
+    userId,
+    day: new Date(date),
+    total,
+  }));
+
+  for (let i = 0; i < rows.length; i += CALENDAR_BATCH_SIZE) {
+    const chunk = rows.slice(i, i + CALENDAR_BATCH_SIZE);
+    await tx
+      .createQueryBuilder()
+      .insert()
+      .into(AppUserRollingActivityEntity)
+      .values(chunk)
+      .orUpdate(['total'], ['user_id', 'day'])
+      .execute();
+  }
 }
 
 export async function replaceUserDailyContributions(

--- a/src/pipeline-v2/pipeline-v2.module.ts
+++ b/src/pipeline-v2/pipeline-v2.module.ts
@@ -8,6 +8,7 @@ import { AppRepositoryEntity } from '../database/entities/app/repository.entity.
 import { AppUserActivityEntity } from '../database/entities/app/user-activity.entity.js';
 import { AppUserSyncEntity } from '../database/entities/app/user-sync.entity.js';
 import { AppUserDailyContributionEntity } from '../database/entities/app/user-daily-contribution.entity.js';
+import { AppUserRollingActivityEntity } from '../database/entities/app/user-rolling-activity.entity.js';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { AppUserDailyContributionEntity } from '../database/entities/app/user-da
       AppUserActivityEntity,
       AppUserSyncEntity,
       AppUserDailyContributionEntity,
+      AppUserRollingActivityEntity,
     ]),
   ],
   controllers: [PipelineV2Controller],

--- a/src/pipeline-v2/pipeline-v2.service.ts
+++ b/src/pipeline-v2/pipeline-v2.service.ts
@@ -9,6 +9,8 @@ import {
   upsertRepositories,
   replaceUserActivity,
   replaceUserDailyContributions,
+  replaceUserRollingActivity,
+  computeRollingActivity,
   markUserReady,
 } from '../ingest/persistence.js';
 import { MIN_FORK_COUNT } from '../ingest/constants.js';
@@ -17,6 +19,7 @@ import { AppRepositoryEntity } from '../database/entities/app/repository.entity.
 import { AppUserActivityEntity } from '../database/entities/app/user-activity.entity.js';
 import { AppUserSyncEntity } from '../database/entities/app/user-sync.entity.js';
 import { AppUserDailyContributionEntity } from '../database/entities/app/user-daily-contribution.entity.js';
+import { AppUserRollingActivityEntity } from '../database/entities/app/user-rolling-activity.entity.js';
 
 interface RepoActivityCounts {
   commits: number;
@@ -76,6 +79,8 @@ export class PipelineV2Service {
     private readonly syncRepo: Repository<AppUserSyncEntity>,
     @InjectRepository(AppUserDailyContributionEntity)
     private readonly dailyRepo: Repository<AppUserDailyContributionEntity>,
+    @InjectRepository(AppUserRollingActivityEntity)
+    private readonly rollingRepo: Repository<AppUserRollingActivityEntity>,
     private readonly ingest: GraphqlIngestService,
   ) {}
 
@@ -85,40 +90,72 @@ export class PipelineV2Service {
       const users: string[] = JSON.parse(usersJson);
       this.logger.log(`Refreshing ${users.length} users from users.json`);
 
-      // Phase 1: fetch all from GitHub concurrently (no DB writes yet)
+      // Phase 1: fetch all from GitHub concurrently (no DB writes yet).
+      // Two windows per user, run sequentially per user (180d then 365d) to
+      // halve the burst rate against GitHub's secondary rate limit while still
+      // running all users in parallel:
+      //   - 180d: source of truth for table data (per-repo counts, summary)
+      //   - 365d: source of daily contribution data, used to compute the
+      //     rolling-180d-window time series (graph)
+      //
+      // FUTURE OPTIMIZATION: 365d events are a strict superset of 180d. A
+      // single 365d fetch with date-filtered aggregate could halve the load,
+      // but the current overflow path (fetchOverflowCounts) uses different
+      // semantics than bucket counts (search updated:>= vs occurredAt;
+      // defaultBranchRef.history vs all-branch commit contributions), so naive
+      // single-fetch produces incorrect table totals. Doable but needs flat
+      // events plumbed into aggregate.
       const fetched = await Promise.all(
-        users.map((login) => this.ingest.fetchUser(login)),
+        users.map(async (login) => {
+          const main180 = await this.ingest.fetchUser(login, 180);
+          const full365 = await this.ingest.fetchUser(login, 365);
+          return { main: main180, daily365: full365 };
+        }),
       );
 
-      const successful = fetched.filter((r) => r.status === 'ready');
-      const failed = fetched.filter((r) => r.status !== 'ready');
+      const successful = fetched.filter(
+        (r) => r.main.status === 'ready' && r.daily365.status === 'ready',
+      );
+      const failed = fetched.filter(
+        (r) => r.main.status !== 'ready' || r.daily365.status !== 'ready',
+      );
 
       // Phase 2: single atomic transaction — wipe everything + write all results
       await this.syncRepo.manager.transaction(async (tx) => {
         await tx.clear(AppUserActivityEntity);
         await tx.clear(AppUserDailyContributionEntity);
+        await tx.clear(AppUserRollingActivityEntity);
         await tx.clear(AppUserProfileEntity);
         await tx.clear(AppUserSyncEntity);
         await tx.clear(AppRepositoryEntity);
 
         for (const r of successful) {
-          if (r.status !== 'ready') continue;
-          await upsertUserProfile(tx, r.user);
-          await upsertRepositories(tx, r.perRepo);
-          await replaceUserActivity(tx, r.user, r.perRepo);
-          await replaceUserDailyContributions(tx, r.user, r.dailyCounts);
-          await markUserReady(tx, r.user);
+          if (r.main.status !== 'ready' || r.daily365.status !== 'ready')
+            continue;
+          await upsertUserProfile(tx, r.main.user);
+          await upsertRepositories(tx, r.main.perRepo);
+          await replaceUserActivity(tx, r.main.user, r.main.perRepo);
+          await replaceUserDailyContributions(
+            tx,
+            r.main.user,
+            r.main.dailyCounts,
+          );
+          const rolling = computeRollingActivity(r.daily365.dailyCounts, 180);
+          await replaceUserRollingActivity(tx, r.main.user, rolling);
+          await markUserReady(tx, r.main.user);
         }
 
         for (const r of failed) {
+          // Surface whichever fetch failed (or both, if both failed).
+          const reason = r.main.status !== 'ready' ? r.main : r.daily365;
           await tx
             .createQueryBuilder()
             .insert()
             .into(AppUserSyncEntity)
             .values({
-              login: r.login,
-              status: r.status,
-              lastError: r.error,
+              login: reason.login,
+              status: reason.status,
+              lastError: 'error' in reason ? reason.error : undefined,
               updatedAt: () => 'NOW()',
             })
             .orUpdate(['status', 'last_error', 'updated_at'], ['login'])
@@ -132,8 +169,8 @@ export class PipelineV2Service {
 
       return {
         message: 'Refresh completed',
-        successfulUsers: successful.map((r) => r.login),
-        failedUsers: failed.map((r) => r.login),
+        successfulUsers: successful.map((r) => r.main.login),
+        failedUsers: failed.map((r) => r.main.login),
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -240,24 +277,24 @@ export class PipelineV2Service {
       else activitiesByUser.set(a.user_id, [a]);
     }
 
-    const dailyRows =
+    const rollingRows =
       userIds.length === 0
         ? []
-        : await this.dailyRepo.find({
+        : await this.rollingRepo.find({
             where: { userId: In(userIds), day: MoreThanOrEqual(since) },
             order: { day: 'ASC' },
           });
-    const dailyByUser = new Map<
+    const rollingByUser = new Map<
       string,
-      Array<{ date: string; count: number }>
+      Array<{ date: string; total: number }>
     >();
-    for (const d of dailyRows) {
-      const arr = dailyByUser.get(d.userId);
+    for (const r of rollingRows) {
+      const arr = rollingByUser.get(r.userId);
       const dateStr =
-        typeof d.day === 'string' ? d.day : d.day.toISOString().slice(0, 10);
-      const entry = { date: dateStr, count: d.count };
+        typeof r.day === 'string' ? r.day : r.day.toISOString().slice(0, 10);
+      const entry = { date: dateStr, total: r.total };
       if (arr) arr.push(entry);
-      else dailyByUser.set(d.userId, [entry]);
+      else rollingByUser.set(r.userId, [entry]);
     }
 
     const usersOut = users.map((u) => {
@@ -283,7 +320,7 @@ export class PipelineV2Service {
         },
         repos: userRepos,
         summary: this.calculateUserSummary(userRepos),
-        dailyContributions: dailyByUser.get(u.userId) ?? [],
+        rollingActivity: rollingByUser.get(u.userId) ?? [],
       };
     });
 
@@ -320,29 +357,29 @@ export class PipelineV2Service {
       contributorsByRepoId,
     );
 
-    const dailyTotals = this.buildCommunityTimeline(dailyRows);
+    const communityRolling = this.buildCommunityRollingTimeline(rollingRows);
 
     return {
       users: usersOut,
       globalSummary,
       repoLeaderboard,
-      dailyTotals,
+      communityRolling,
       excludedUsers: [],
     };
   }
 
-  private buildCommunityTimeline(
-    dailyRows: AppUserDailyContributionEntity[],
-  ): Array<{ date: string; count: number }> {
+  private buildCommunityRollingTimeline(
+    rollingRows: AppUserRollingActivityEntity[],
+  ): Array<{ date: string; total: number }> {
     const byDay = new Map<string, number>();
-    for (const d of dailyRows) {
+    for (const r of rollingRows) {
       const date =
-        typeof d.day === 'string' ? d.day : d.day.toISOString().slice(0, 10);
-      byDay.set(date, (byDay.get(date) || 0) + d.count);
+        typeof r.day === 'string' ? r.day : r.day.toISOString().slice(0, 10);
+      byDay.set(date, (byDay.get(date) || 0) + r.total);
     }
     return [...byDay.entries()]
       .sort((a, b) => a[0].localeCompare(b[0]))
-      .map(([date, count]) => ({ date, count }));
+      .map(([date, total]) => ({ date, total }));
   }
 
   private async buildRepoLeaderboard(


### PR DESCRIPTION
For each day in the last 180 days, store the total OSS contributions in
the 180 days ending on that day. Surfaces a time-series showing how a
user's '6 months of activity' has trended over time, instead of a
cumulative-from-zero curve.

- New table user_rolling_activity (user_id, day, total) + migration
- computeRollingActivity helper + unit tests
- analytics/report exposes rollingActivity per user and a
  communityRolling aggregate

Refresh changes:
- Dual fetch (180d for table, 365d for rolling source), run sequentially
  per user inside the parallel user fan-out, to halve the burst rate
  against GitHub's secondary rate limit.
- Window boundaries anchored to today's midnight UTC so two refreshes on
  the same calendar day return identical events (no inter-refresh drift).

Future optimizations (left as in-code TODOs):
- Single 365d fetch with date-filtered aggregate (instead of dual). Halves
  GraphQL load. Blocked on plumbing flat-pagination events into aggregate
  so bucket-overflow repos count correctly without falling back to
  fetchOverflowCounts (which has different semantics: search updated:>=
  vs occurredAt; defaultBranchRef.history vs all-branch contributions).
- Bulk inserts in refreshAll: collect rows across all users first, then
  one INSERT per table chunked by Postgres parameter limits. Current
  per-user INSERTs are fine at 17 users; would matter at 1000+.