### PR TITLE
fix(refresh): make refresh resilient to GitHub 5xx and rate limits

### DIFF
--- a/src/ingest/graphql-client.ts
+++ b/src/ingest/graphql-client.ts
@@ -2,7 +2,12 @@ import type { GraphqlErrorBody } from './graphql-types.js';
 
 const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
 const USER_AGENT = 'maakaf-friends-activity/1.0';
-const MAX_ATTEMPTS = 3;
+const MAX_ATTEMPTS = 5;
+// Backoff before each retry attempt, in milliseconds. Heavy queries can hit
+// transient GitHub 5xx errors; the daily cron has plenty of time so we wait
+// generously to give GitHub's load shedding a chance to clear.
+//   1: ~1s  2: ~30s  3: ~3min  4: ~10min  5: ~30min  (total max ≈ 43min)
+const BACKOFF_MS = [1_000, 30_000, 180_000, 600_000, 1_800_000];
 
 export class GraphqlClient {
   constructor(private readonly token: string) {}
@@ -22,12 +27,32 @@ export class GraphqlClient {
           body: JSON.stringify({ query, variables }),
         });
         if (res.ok) break;
-        if (res.status < 500 || attempt === MAX_ATTEMPTS) break;
+        // Retry 5xx (transient server errors) and 403 with Retry-After
+        // (secondary rate limit / abuse detection). Don't retry 401, 404,
+        // 422, etc. — those are real failures.
+        const isTransient =
+          res.status >= 500 ||
+          (res.status === 403 && res.headers.get('Retry-After') != null);
+        if (!isTransient || attempt === MAX_ATTEMPTS) break;
       } catch (e) {
         lastErr = e;
         if (attempt === MAX_ATTEMPTS) throw e;
       }
-      await new Promise((r) => setTimeout(r, 500 * attempt));
+      // If GitHub told us how long to wait (Retry-After in seconds), honor it
+      // and add a small buffer + positive-only jitter — never undercut what
+      // GitHub asked. Otherwise use our backoff schedule with ±20% jitter
+      // so concurrent users don't all retry at the same instant.
+      const retryAfterSec = Number(res?.headers.get('Retry-After'));
+      let ms: number;
+      if (Number.isFinite(retryAfterSec) && retryAfterSec > 0) {
+        // GitHub said wait N seconds → wait N + 5s buffer + 0-3s jitter.
+        ms = retryAfterSec * 1000 + 5_000 + Math.round(Math.random() * 3_000);
+      } else {
+        const baseMs =
+          BACKOFF_MS[attempt - 1] ?? BACKOFF_MS[BACKOFF_MS.length - 1];
+        ms = Math.round(baseMs * (0.8 + Math.random() * 0.4));
+      }
+      await new Promise((r) => setTimeout(r, ms));
     }
     if (!res) {
       if (lastErr instanceof Error) throw lastErr;

--- a/src/pipeline-v2/pipeline-v2.service.ts
+++ b/src/pipeline-v2/pipeline-v2.service.ts
@@ -98,6 +98,10 @@ export class PipelineV2Service {
       //   - 365d: source of daily contribution data, used to compute the
       //     rolling-180d-window time series (graph)
       //
+      // Users are released in batches of BATCH_SIZE with a random delay
+      // between batches so we don't slam GitHub with all users at once.
+      // Within a batch users still run in parallel.
+      //
       // FUTURE OPTIMIZATION: 365d events are a strict superset of 180d. A
       // single 365d fetch with date-filtered aggregate could halve the load,
       // but the current overflow path (fetchOverflowCounts) uses different
@@ -105,8 +109,15 @@ export class PipelineV2Service {
       // defaultBranchRef.history vs all-branch commit contributions), so naive
       // single-fetch produces incorrect table totals. Doable but needs flat
       // events plumbed into aggregate.
+      const BATCH_SIZE = 10;
       const fetched = await Promise.all(
-        users.map(async (login) => {
+        users.map(async (login, idx) => {
+          const batchIdx = Math.floor(idx / BATCH_SIZE);
+          if (batchIdx > 0) {
+            // Random 2–10s wait per preceding batch
+            const delayMs = batchIdx * (2_000 + Math.random() * 8_000);
+            await new Promise((r) => setTimeout(r, delayMs));
+          }
           const main180 = await this.ingest.fetchUser(login, 180);
           const full365 = await this.ingest.fetchUser(login, 365);
           return { main: main180, daily365: full365 };
@@ -120,15 +131,12 @@ export class PipelineV2Service {
         (r) => r.main.status !== 'ready' || r.daily365.status !== 'ready',
       );
 
-      // Phase 2: single atomic transaction — wipe everything + write all results
+      // Phase 2: single atomic transaction — replace per-user data for
+      // successful fetches; failed users keep their previous data so a
+      // transient GitHub 5xx doesn't make a member vanish from the dashboard
+      // until the next refresh succeeds. The replace*() helpers below already
+      // do per-user delete-then-insert, so no global tx.clear() needed.
       await this.syncRepo.manager.transaction(async (tx) => {
-        await tx.clear(AppUserActivityEntity);
-        await tx.clear(AppUserDailyContributionEntity);
-        await tx.clear(AppUserRollingActivityEntity);
-        await tx.clear(AppUserProfileEntity);
-        await tx.clear(AppUserSyncEntity);
-        await tx.clear(AppRepositoryEntity);
-
         for (const r of successful) {
           if (r.main.status !== 'ready' || r.daily365.status !== 'ready')
             continue;


### PR DESCRIPTION
Daily refresh was wiping all data at the start of its transaction, so a transient GitHub 5xx on a single user made them vanish from the dashboard until the next refresh succeeded. Several improvements:

- Per-user atomicity: drop the global tx.clear() and rely on the per-user replace*() helpers (delete-then-insert per user_id). Successful users get fresh data; failed users keep their previous data instead of disappearing.
- Retries bumped 3 → 5 with exponential backoff (~1s, 30s, 3min, 10min, 30min). Heavy users like szabgab/lirantal hit 502 occasionally; the daily cron has time to wait.
- Honor Retry-After header on 403 (secondary rate limit / abuse detection) — previously we bailed on 403. Wait the header value + 5s buffer + small positive jitter, never undercutting GitHub.
- Add ±20% jitter to backoff schedule so concurrent users don't synchronize their retries and hammer GitHub in waves.
- Stagger user starts in batches of 10 with a random 2-10s delay between batches so we don't slam GitHub with 17 simultaneous fetch chains at once. Total wall time barely changes.